### PR TITLE
Refactoring clocks for periodic windows

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Darach Ennis <darach@gmail.com>
 Morton Swimmer <morton@swimmer.org>
 Konrad Sosnowski
+Michael Coles <michael.coles@gmail.com>

--- a/include/eep_erl.hrl
+++ b/include/eep_erl.hrl
@@ -32,6 +32,9 @@
   interval = 1 :: integer()
 }).
 
+-type ck_state() :: #eep_clock{}.
+-export_type([ck_state/0]).
+
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.

--- a/rebar.config
+++ b/rebar.config
@@ -8,10 +8,14 @@
   debug_info,
   warn_export_all,
   warn_obsolete_guard,
-  warn_unused_import,
+  %warn_unused_import, %% PropEr causes problems here
   warn_unused_vars,
   warn_shadow_vars,  
   warnings_as_errors
 ]}.
+
+{deps, [
+    {proper, ".*", {git, "https://github.com/manopapad/proper.git", {branch, "master"}}}
+    ]}.
 
 {clean_files, ["test/*.beam"]}.

--- a/src/eep_clock.erl
+++ b/src/eep_clock.erl
@@ -38,5 +38,5 @@
     New :: ck_state().
 -callback tick(Old :: ck_state()) ->
     {Tocked :: boolean(), New :: ck_state()}.
--callback tock(Old :: ck_state(), Elapsed :: integer()) ->
+-callback tock(Old :: ck_state()) ->
     {Tocked :: boolean(), New :: ck_state()}.

--- a/src/eep_clock.erl
+++ b/src/eep_clock.erl
@@ -26,10 +26,17 @@
 
 -module(eep_clock).
 
--export([behaviour_info/1]).
+-include_lib("eep_erl.hrl").
 
-behaviour_info(callbacks) ->
-  [ {name, 0} , {at, 1}, {new, 1}, {inc, 1}, {tick, 1}, {tock, 2} ];
-
-behaviour_info(_) ->
-  undefined.
+-callback name() ->
+    Name :: atom().
+-callback at(ck_state()) ->
+    Now :: integer().
+-callback new(Interval :: integer()) ->
+    ck_state().
+-callback inc(Old :: ck_state()) ->
+    New :: ck_state().
+-callback tick(Old :: ck_state()) ->
+    {Tocked :: boolean(), New :: ck_state()}.
+-callback tock(Old :: ck_state(), Elapsed :: integer()) ->
+    {Tocked :: boolean(), New :: ck_state()}.

--- a/src/eep_clock_count.erl
+++ b/src/eep_clock_count.erl
@@ -36,7 +36,7 @@
 -export([new/1]).
 -export([inc/1]).
 -export([tick/1]).
--export([tock/2]).
+-export([tock/1]).
 
 name() -> count.
 
@@ -53,7 +53,7 @@ tick(State) ->
   NewState = inc(State),
   {(NewState#eep_clock.at - NewState#eep_clock.mark) >= NewState#eep_clock.interval, NewState}.
 
-tock(State, _Elapsed) ->
+tock(State) ->
     #eep_clock{mark=Mark, interval=Interval} = State,
     Delta = State#eep_clock.at,
     case Delta >= State#eep_clock.interval of

--- a/src/eep_clock_count.erl
+++ b/src/eep_clock_count.erl
@@ -50,15 +50,17 @@ inc(State) ->
   State#eep_clock{at = State#eep_clock.at + 1}.
 
 tick(State) ->
-  NewState = case State#eep_clock.mark of
+  MarkedState = case State#eep_clock.mark of
     undefined -> State#eep_clock{mark = State#eep_clock.at};
     _Other -> State
   end,
+  NewState = inc(MarkedState),
   {(NewState#eep_clock.at - NewState#eep_clock.mark) >= NewState#eep_clock.interval, NewState}.
 
 tock(State, _Elapsed) ->
-  Delta = State#eep_clock.at,
-  case Delta >= State#eep_clock.interval of
-    true -> {true, State#eep_clock{mark = State#eep_clock.mark + State#eep_clock.interval}};
-    false -> {false, State}
-  end.
+    #eep_clock{mark=Mark, interval=Interval} = State,
+    Delta = State#eep_clock.at,
+    case Delta >= State#eep_clock.interval of
+        true -> {true, State#eep_clock{mark = (Mark + Interval)}};
+        false -> {false, State}
+    end.

--- a/src/eep_clock_count.erl
+++ b/src/eep_clock_count.erl
@@ -41,20 +41,16 @@
 name() -> count.
 
 at(State) -> 
- State#eep_clock.at.
+ State#eep_clock.mark.
 
 new(Interval) ->
-  #eep_clock{at = 0, interval = Interval}.
+  #eep_clock{at = 0, mark = 0, interval = Interval}.
 
 inc(State) -> 
   State#eep_clock{at = State#eep_clock.at + 1}.
 
 tick(State) ->
-  MarkedState = case State#eep_clock.mark of
-    undefined -> State#eep_clock{mark = State#eep_clock.at};
-    _Other -> State
-  end,
-  NewState = inc(MarkedState),
+  NewState = inc(State),
   {(NewState#eep_clock.at - NewState#eep_clock.mark) >= NewState#eep_clock.interval, NewState}.
 
 tock(State, _Elapsed) ->

--- a/src/eep_clock_wall.erl
+++ b/src/eep_clock_wall.erl
@@ -45,7 +45,7 @@
 name() -> crock.
 
 at(State) -> 
- State#eep_clock.at.
+ State#eep_clock.mark.
 
 new(Interval) ->
   At = ts(),

--- a/src/eep_clock_wall.erl
+++ b/src/eep_clock_wall.erl
@@ -59,8 +59,8 @@ tick(State) ->
   NewState = inc(State),
   {(NewState#eep_clock.at - NewState#eep_clock.mark) >= 0, NewState}.
 
-tock(State, Elapsed) ->
-  Delta = State#eep_clock.at - Elapsed,
+tock(State, _Since) ->
+  Delta = State#eep_clock.at - State#eep_clock.mark,
   case Delta >= State#eep_clock.interval of
     true -> {true, State#eep_clock{mark = State#eep_clock.mark + State#eep_clock.interval}};
     false -> {false, State}

--- a/src/eep_clock_wall.erl
+++ b/src/eep_clock_wall.erl
@@ -37,7 +37,7 @@
 -export([new/1]).
 -export([inc/1]).
 -export([tick/1]).
--export([tock/2]).
+-export([tock/1]).
 
 %% impl
 -export([ts/0]).
@@ -59,7 +59,7 @@ tick(State) ->
   NewState = inc(State),
   {(NewState#eep_clock.at - NewState#eep_clock.mark) >= 0, NewState}.
 
-tock(State, _Since) ->
+tock(State) ->
   Delta = State#eep_clock.at - State#eep_clock.mark,
   case Delta >= State#eep_clock.interval of
     true -> {true, State#eep_clock{mark = State#eep_clock.mark + State#eep_clock.interval}};

--- a/src/eep_window_monotonic.erl
+++ b/src/eep_window_monotonic.erl
@@ -121,7 +121,7 @@ tick(#state{mod=Mod, seed=Seed, aggregate=Agg, clock_mod=ClockMod, clock=Clock, 
 		    case ClockMod:tock(Tocked, ClockMod:at(Tocked)) of
 			{true, Clock1} ->
                 CallbackFun(Agg),
-                {emit,State#state{aggregate=Mod:init(Seed),clock=ClockMod:inc(Clock1)}};
+                {emit,State#state{aggregate=Mod:init(Seed),clock=Clock1}};
 			{false, _Clock1} ->
                 {noop,State#state{aggregate=Mod:init(Seed),clock=Tocked}}
 		    end;

--- a/src/eep_window_monotonic.erl
+++ b/src/eep_window_monotonic.erl
@@ -118,7 +118,7 @@ tick(#state{mod=Mod, seed=Seed, aggregate=Agg, clock_mod=ClockMod, clock=Clock, 
 	{ Ticked, Tocked } =  ClockMod:tick(Clock),
 	case Ticked of
 		true ->
-		    case ClockMod:tock(Tocked, ClockMod:at(Tocked)) of
+		    case ClockMod:tock(Tocked) of
 			{true, Clock1} ->
                 CallbackFun(Agg),
                 {emit,State#state{aggregate=Mod:init(Seed),clock=Clock1}};

--- a/src/eep_window_periodic.erl
+++ b/src/eep_window_periodic.erl
@@ -56,8 +56,8 @@ start(Mod, Interval) ->
         )
     end,
 
-  {_, Clock} = eep_clock_wall:tick(eep_clock_wall:new(Interval)),
-  spawn(?MODULE, loop, [#state{mod=Mod, clock=Clock, pid=EventPid, aggregate=Mod:init(), callback=CallbackFun, epoch=eep_clock_wall:ts(), interval=Interval}]).
+    State = new(Mod, CallbackFun, Interval),
+    spawn(?MODULE, loop, [State]).
 
 -spec new(Mod::module(), CallbackFun::fun((...) -> any()), Integer::integer()) -> #state{}.
 new(Mod, CallbackFun, Interval) ->
@@ -116,4 +116,3 @@ tick(#state{mod=Mod, seed=Seed, aggregate=Agg,clock=Clock,callback=CallbackFun,e
         false ->
             {noop,State}
     end.
-    

--- a/src/eep_window_periodic.erl
+++ b/src/eep_window_periodic.erl
@@ -124,5 +124,5 @@ tick(#state{callback=CallbackFun, agg_mod=AggMod, aggregate=Agg,
                     {noop,State#state{aggregate=AggMod:init(Seed),clock=Tocked, epoch=Epoch}}
             end;
         false ->
-            {noop,State}
+            {noop,State#state{clock=Tocked}}
     end.

--- a/src/eep_window_periodic.erl
+++ b/src/eep_window_periodic.erl
@@ -72,7 +72,7 @@ new(AggMod, ClockMod, CallbackFun, Interval) ->
 
 -spec new(AggMod::module(), ClockMod::module(), Seed::list(), CallbackFun::fun((...) -> any()), Integer::integer()) -> #state{}.
 new(AggMod, ClockMod, Seed, CallbackFun, Interval) ->
-    {_, Clock} = ClockMod:tick(ClockMod:new(Interval)),
+    Clock = ClockMod:new(Interval),
     #state{agg_mod=AggMod, aggregate=AggMod:init(Seed),
            clock_mod=ClockMod, clock=Clock, epoch=ClockMod:at(Clock), seed=Seed, interval=Interval,
            callback=CallbackFun}.
@@ -103,12 +103,8 @@ loop(#state{pid=EventPid}=State) ->
       loop(State)
   end.
 
-accum(#state{agg_mod=AggMod, aggregate=Agg,
-             clock_mod=CkMod, clock=Clock}=State,Event) ->
-    {noop, State#state{
-        clock=CkMod:inc(Clock),
-        aggregate=AggMod:accumulate(Agg, Event)
-    }}.
+accum(#state{agg_mod=AggMod, aggregate=Agg}=State,Event) ->
+    {noop, State#state{ aggregate=AggMod:accumulate(Agg, Event) }}.
 
 tick(#state{callback=CallbackFun, agg_mod=AggMod, aggregate=Agg,
             clock_mod=CkMod, clock=Clock,

--- a/src/eep_window_periodic.erl
+++ b/src/eep_window_periodic.erl
@@ -60,8 +60,7 @@ start(AggMod, Interval) ->
 
 -spec new(AggMod::module(), CallbackFun::fun((...) -> any()), Integer::integer()) -> #state{}.
 new(AggMod, CallbackFun, Interval) ->
-    {_, Clock} = eep_clock_wall:tick(eep_clock_wall:new(Interval)),
-    #state{agg_mod=AggMod, clock=Clock, aggregate=AggMod:init(), callback=CallbackFun, epoch=eep_clock_wall:ts(),interval=Interval}.
+    new(AggMod, [], CallbackFun, Interval).
 
 -spec new(AggMod::module(), Seed::list(), CallbackFun::fun((...) -> any()), Integer::integer()) -> #state{}.
 new(AggMod, Seed, CallbackFun, Interval) ->

--- a/test/eep_erl_SUITE.erl
+++ b/test/eep_erl_SUITE.erl
@@ -50,7 +50,7 @@
 -include_lib("common_test/include/ct.hrl").
 
 -define(proptest(TC), proper:quickcheck(TC)
-                        orelse ct:fail({proper:counterexample(TC)})).
+                        orelse ct:fail({counterexample, proper:counterexample(TC)})).
 
 all() ->
     [

--- a/test/eep_erl_SUITE.erl
+++ b/test/eep_erl_SUITE.erl
@@ -111,7 +111,7 @@ t_clock_wall(_Config) ->
     true = (C1#eep_clock.at - T0) >= 1,
     T1 = C1#eep_clock.at,
     {true,C2} = eep_clock_wall:tick(C1),
-    {true,C3} = eep_clock_wall:tock(C2,unused),
+    {true,C3} = eep_clock_wall:tock(C2),
     true = C3#eep_clock.mark =< T1.
 
 t_clock_count(_Config) ->
@@ -121,11 +121,11 @@ t_clock_count(_Config) ->
   {false, C1} = eep_clock_count:tick(C0),
   0  = eep_clock_count:at(C1),
   {true,C2} = eep_clock_count:tick(C1),
-  {true,C3}  = eep_clock_count:tock(C2,notused),
+  {true,C3}  = eep_clock_count:tock(C2),
   {false,C4}  = eep_clock_count:tick(C3),
 
-  {true, C5} = eep_clock_count:tock(C4,notused),
-  {true,C6} = eep_clock_count:tock(C5,notused),
+  {true, C5} = eep_clock_count:tock(C4),
+  {true,C6} = eep_clock_count:tock(C5),
   6 = eep_clock_count:at(C6),
   6 = C6#eep_clock.mark.
 

--- a/test/eep_erl_SUITE.erl
+++ b/test/eep_erl_SUITE.erl
@@ -49,6 +49,9 @@
 -include("eep_erl.hrl").
 -include_lib("common_test/include/ct.hrl").
 
+-define(proptest(TC), proper:quickcheck(TC)
+                        orelse ct:fail({proper:counterexample(TC)})).
+
 all() ->
     [
         {group, clock},
@@ -324,10 +327,10 @@ t_seedable_aggregate(_Config) ->
     ok.
 
 t_avg_aggregate_accum(_) ->
-    true = proper:quickcheck(prop_eep:prop_avg_aggregate_accum()).
+    ?proptest(prop_eep:prop_avg_aggregate_accum()).
 
 t_monotonic_clock_count(_) ->
-    true = proper:quickcheck(prop_eep:prop_monotonic_clock_count()).
+    ?proptest(prop_eep:prop_monotonic_clock_count()).
 
 t_periodic_window(_) ->
-    true = proper:quickcheck(prop_eep:prop_monotonic_clock_count()).
+    ?proptest(prop_eep:prop_monotonic_clock_count()).

--- a/test/eep_erl_SUITE.erl
+++ b/test/eep_erl_SUITE.erl
@@ -101,35 +101,33 @@ init_per_suite(Config) ->
 t_clock_wall(_Config) ->
     crock = eep_clock_wall:name(),
     C0 = eep_clock_wall:new(1),
-    {eep_clock,At,_,_} = C0,
+    {eep_clock,_,At,_} = C0,
     At = eep_clock_wall:at(C0),
     timer:sleep(1),
     T0 = eep_clock_wall:ts(),
-    case ((T0 - C0#eep_clock.at) >= 1) of true -> ok end,
+    true = (T0 - C0#eep_clock.at) >= 1,
     timer:sleep(1),
-    C1 = eep_clock_wall:inc(C0),
-    case ((C1#eep_clock.at - T0) >= 1) of true -> ok end,
+    {true, C1} = eep_clock_wall:tick(C0),
+    true = (C1#eep_clock.at - T0) >= 1,
     T1 = C1#eep_clock.at,
     {true,C2} = eep_clock_wall:tick(C1),
-    {false,C3} = eep_clock_wall:tock(C2,eep_clock_wall:ts() + 1),
-    {true,_C4} = eep_clock_wall:tock(C2,2),
+    {true,C3} = eep_clock_wall:tock(C2,unused),
     true = C3#eep_clock.mark =< T1.
 
 t_clock_count(_Config) ->
   count = eep_clock_count:name(),
   C0 = eep_clock_count:new(2),
   0  = eep_clock_count:at(C0),
-  C1 = eep_clock_count:inc(C0),
-  1  = eep_clock_count:at(C1),
-  {_false,C2} = eep_clock_count:tick(C1),
-  {_true,C3}  = eep_clock_count:tick(C2),
-  {_true,C4}  = eep_clock_count:tock(C3,notused),
+  {false, C1} = eep_clock_count:tick(C0),
+  0  = eep_clock_count:at(C1),
+  {true,C2} = eep_clock_count:tick(C1),
+  {true,C3}  = eep_clock_count:tock(C2,notused),
+  {false,C4}  = eep_clock_count:tick(C3),
 
-  C5 = eep_clock_count:inc(C4),
-  {true, C6} = eep_clock_count:tock(C5,notused),
-  {true,C7} = eep_clock_count:tock(C6,notused),
-  4 = eep_clock_count:at(C7),
-  7 = C7#eep_clock.mark.
+  {true, C5} = eep_clock_count:tock(C4,notused),
+  {true,C6} = eep_clock_count:tock(C5,notused),
+  6 = eep_clock_count:at(C6),
+  6 = C6#eep_clock.mark.
 
 t_win_tumbling_inline(_Config) ->
     W0  = eep_window_tumbling:new(eep_stats_count, fun(_Callback) -> boop end, 2),
@@ -227,9 +225,9 @@ t_win_periodic_inline(_Config) ->
     W0 = eep_window_periodic:new(eep_stats_count, fun(_) -> boop end, 0),
     {noop,W1} = eep_window_periodic:push(W0,foo),
     {noop,W2} = eep_window_periodic:push(W1,bar),
-    {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},2,_,undefined,_} = W2,
+    {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},2,_,undefined} = W2,
     {emit,W3} = eep_window_periodic:tick(W2),
-    {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_,undefined,_} = W3,
+    {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_,undefined} = W3,
     {noop,W4} = eep_window_periodic:push(W3,foo),
     {noop,W5} = eep_window_periodic:push(W4,bar),
     {noop,W6} = eep_window_periodic:push(W5,foo),
@@ -237,7 +235,7 @@ t_win_periodic_inline(_Config) ->
     {noop,W8} = eep_window_periodic:push(W7,foo),
     {noop,W9} = eep_window_periodic:push(W8,bar),
     {emit,W10} = eep_window_periodic:tick(W9),
-    {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_,undefined,_} = W10,
+    {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_,undefined} = W10,
     ok.
 
 t_win_periodic_process(_Config) ->
@@ -246,12 +244,12 @@ t_win_periodic_process(_Config) ->
   Pid ! {push, bar},
   Pid ! {debug, self()},
   receive
-    { debug, Debug0 } -> {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},2,_,_,_} = Debug0
+    { debug, Debug0 } -> {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},2,_,_} = Debug0
   end,
   Pid ! tick,
   Pid ! {debug, self()},
   receive
-    { debug, Debug1 } -> {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_,_,_} = Debug1
+    { debug, Debug1 } -> {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_,_} = Debug1
   end,
   Pid ! {push, foo},
   Pid ! {push, bar},
@@ -261,12 +259,12 @@ t_win_periodic_process(_Config) ->
   Pid ! {push, bar},
   Pid ! {debug, self()},
   receive
-    { debug, Debug2 } -> {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},6,_,_,_} = Debug2
+    { debug, Debug2 } -> {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},6,_,_} = Debug2
   end,
   Pid ! tick,
   Pid ! {debug, self()},
   receive
-    { debug, Debug3 } -> {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_,_,_} = Debug3
+    { debug, Debug3 } -> {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_,_} = Debug3
   end,
   Pid ! stop.
 

--- a/test/eep_erl_SUITE.erl
+++ b/test/eep_erl_SUITE.erl
@@ -109,20 +109,18 @@ t_clock_wall(_Config) ->
 t_clock_count(_Config) ->
   count = eep_clock_count:name(),
   C0 = eep_clock_count:new(2),
-  0 = eep_clock_count:at(C0),
-  T0 = 0,
-  case (T0 - C0#eep_clock.at) =:= 0 of true -> ok end,
+  0  = eep_clock_count:at(C0),
   C1 = eep_clock_count:inc(C0),
-  1 = eep_clock_count:at(C1),
-  case (C1#eep_clock.at - T0) =:= 1 of true -> ok end,
-  {false,C2} = eep_clock_count:tick(C1),
-  {false,C2} = eep_clock_count:tick(C2),
-  {false,C2} = eep_clock_count:tock(C2,notused),
-  C3 = eep_clock_count:inc(C2),
-  {false,C2} = eep_clock_count:tock(C2,notused),
-  {true,C4} = eep_clock_count:tock(C3,notused),
-  2 = eep_clock_count:at(C4),
-  3 = C4#eep_clock.mark.
+  1  = eep_clock_count:at(C1),
+  {_false,C2} = eep_clock_count:tick(C1),
+  {_true,C3}  = eep_clock_count:tick(C2),
+  {_true,C4}  = eep_clock_count:tock(C3,notused),
+
+  C5 = eep_clock_count:inc(C4),
+  {true, C6} = eep_clock_count:tock(C5,notused),
+  {true,C7} = eep_clock_count:tock(C6,notused),
+  4 = eep_clock_count:at(C7),
+  7 = C7#eep_clock.mark.
 
 t_win_tumbling_inline(_Config) ->
     W0  = eep_window_tumbling:new(eep_stats_count, fun(_Callback) -> boop end, 2),
@@ -267,7 +265,7 @@ t_win_monotonic_inline(_Config) ->
     W0 = eep_window_monotonic:new(eep_stats_count, eep_clock_count, fun(_) -> boop end, 0),
     {noop,W1} = eep_window_monotonic:push(W0,foo),
     {noop,W2} = eep_window_monotonic:push(W1,bar),
-    {state,undefined,eep_stats_count,[],eep_clock_count,{eep_clock,2,0,0},2,_,undefined} = W2,
+    {state,undefined,eep_stats_count,[],eep_clock_count,{eep_clock,3,0,0},2,_,undefined} = W2,
     {emit,W3} = eep_window_monotonic:tick(W2),
     {state,undefined,eep_stats_count,[],eep_clock_count,{eep_clock,_,_,0},0,_,undefined} = W3,
     {noop,W4} = eep_window_monotonic:push(W3,foo),
@@ -286,12 +284,12 @@ t_win_monotonic_process(_config) ->
     Pid ! {push, bar},
     Pid ! {debug, self()},
     receive
-    { debug, Debug0 } -> {state,undefined,eep_stats_count,[],eep_clock_count, {eep_clock,2,0,0},2,_,_}  = Debug0
+    { debug, Debug0 } -> {state,undefined,eep_stats_count,[],eep_clock_count, {eep_clock,3,0,0},2,_,_}  = Debug0
     end,
     Pid ! tick,
     Pid ! {debug, self()},
     receive
-    { debug, Debug1 } -> {state,undefined,eep_stats_count,[],eep_clock_count, {eep_clock,3,0,0},0,_,_}  = Debug1
+    { debug, Debug1 } -> {state,undefined,eep_stats_count,[],eep_clock_count, {eep_clock,4,0,0},0,_,_}  = Debug1
     end,
     Pid ! {push, foo},
     Pid ! {push, bar},
@@ -301,12 +299,12 @@ t_win_monotonic_process(_config) ->
     Pid ! {push, bar},
     Pid ! {debug, self()},
     receive
-    { debug, Debug2 } -> {state,undefined,eep_stats_count,[],eep_clock_count, {eep_clock,9,0,0},6,_,_}  = Debug2
+    { debug, Debug2 } -> {state,undefined,eep_stats_count,[],eep_clock_count, {eep_clock,10,0,0},6,_,_}  = Debug2
     end,
     Pid ! tick,
     Pid ! {debug, self()},
     receive
-    { debug, Debug3 } -> {state,undefined,eep_stats_count,[],eep_clock_count, {eep_clock,10,0,0},0,_,_}  = Debug3
+    { debug, Debug3 } -> {state,undefined,eep_stats_count,[],eep_clock_count, {eep_clock,11,0,0},0,_,_}  = Debug3
     end,
     Pid ! stop.
 

--- a/test/eep_erl_SUITE.erl
+++ b/test/eep_erl_SUITE.erl
@@ -42,6 +42,9 @@
 -export([t_win_monotonic_inline/1]).
 -export([t_win_monotonic_process/1]).
 -export([t_seedable_aggregate/1]).
+-export([t_avg_aggregate_accum/1]).
+-export([t_monotonic_clock_count/1]).
+-export([t_periodic_window/1]).
 
 -include("eep_erl.hrl").
 -include_lib("common_test/include/ct.hrl").
@@ -53,7 +56,8 @@ all() ->
         {group, win_sliding},
         {group, win_periodic},
         {group, win_monotonic},
-        {group, aggregate}
+        {group, aggregate},
+        {group, props}
     ].
 
 suite() ->
@@ -83,6 +87,11 @@ groups() ->
             ]},
         {aggregate, [], [
             t_seedable_aggregate
+            ]},
+        {props, [], [
+            t_avg_aggregate_accum,
+            t_monotonic_clock_count,
+            t_periodic_window
             ]}
     ].
 
@@ -316,3 +325,11 @@ t_seedable_aggregate(_Config) ->
     [meep,moop] = seedable_aggregate:emit([meep,moop]),
     ok.
 
+t_avg_aggregate_accum(_) ->
+    true = proper:quickcheck(prop_eep:prop_avg_aggregate_accum()).
+
+t_monotonic_clock_count(_) ->
+    true = proper:quickcheck(prop_eep:prop_monotonic_clock_count()).
+
+t_periodic_window(_) ->
+    true = proper:quickcheck(prop_eep:prop_monotonic_clock_count()).

--- a/test/eep_erl_SUITE.erl
+++ b/test/eep_erl_SUITE.erl
@@ -220,9 +220,9 @@ t_win_periodic_inline(_Config) ->
     W0 = eep_window_periodic:new(eep_stats_count, fun(_) -> boop end, 0),
     {noop,W1} = eep_window_periodic:push(W0,foo),
     {noop,W2} = eep_window_periodic:push(W1,bar),
-    {state,0,eep_stats_count,[],{eep_clock,_,_,0},2,_,undefined,_} = W2,
+    {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},2,_,undefined,_} = W2,
     {emit,W3} = eep_window_periodic:tick(W2),
-    {state,0,eep_stats_count,[],{eep_clock,_,_,0},0,_,undefined,_} = W3,
+    {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_,undefined,_} = W3,
     {noop,W4} = eep_window_periodic:push(W3,foo),
     {noop,W5} = eep_window_periodic:push(W4,bar),
     {noop,W6} = eep_window_periodic:push(W5,foo),
@@ -230,7 +230,7 @@ t_win_periodic_inline(_Config) ->
     {noop,W8} = eep_window_periodic:push(W7,foo),
     {noop,W9} = eep_window_periodic:push(W8,bar),
     {emit,W10} = eep_window_periodic:tick(W9),
-    {state,0,eep_stats_count,[],{eep_clock,_,_,0},0,_,undefined,_} = W10,
+    {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_,undefined,_} = W10,
     ok.
 
 t_win_periodic_process(_Config) ->
@@ -239,12 +239,12 @@ t_win_periodic_process(_Config) ->
   Pid ! {push, bar},
   Pid ! {debug, self()},
   receive
-    { debug, Debug0 } -> {state,0,eep_stats_count,[],{eep_clock,_,_,0},2,_,_,_} = Debug0
+    { debug, Debug0 } -> {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},2,_,_,_} = Debug0
   end,
   Pid ! tick,
   Pid ! {debug, self()},
   receive
-    { debug, Debug1 } -> {state,0,eep_stats_count,[],{eep_clock,_,_,0},0,_,_,_} = Debug1
+    { debug, Debug1 } -> {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_,_,_} = Debug1
   end,
   Pid ! {push, foo},
   Pid ! {push, bar},
@@ -254,12 +254,12 @@ t_win_periodic_process(_Config) ->
   Pid ! {push, bar},
   Pid ! {debug, self()},
   receive
-    { debug, Debug2 } -> {state,0,eep_stats_count,[],{eep_clock,_,_,0},6,_,_,_} = Debug2
+    { debug, Debug2 } -> {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},6,_,_,_} = Debug2
   end,
   Pid ! tick,
   Pid ! {debug, self()},
   receive
-    { debug, Debug3 } -> {state,0,eep_stats_count,[],{eep_clock,_,_,0},0,_,_,_} = Debug3
+    { debug, Debug3 } -> {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_,_,_} = Debug3
   end,
   Pid ! stop.
 

--- a/test/prop_eep.erl
+++ b/test/prop_eep.erl
@@ -64,7 +64,7 @@ clock_handle(tick, {Clock, Tocks}) ->
         {false, TickedClock} ->
             {TickedClock, Tocks};
         {true, TockingClock} ->
-            case eep_clock_count:tock(TockingClock, undefined) of
+            case eep_clock_count:tock(TockingClock) of
                 {true, Tocked} -> {Tocked, Tocks+1};
                 {false, Tocked} -> {Tocked, Tocks}
             end

--- a/test/prop_eep.erl
+++ b/test/prop_eep.erl
@@ -1,3 +1,29 @@
+%% -------------------------------------------------------------------
+%% Permission is hereby granted, free of charge, to any person obtaining a
+%% copy of this software and associated documentation files (the
+%% "Software"), to deal in the Software without restriction, including
+%% without limitation the rights to use, copy, modify, merge, publish,
+%% distribute, sublicense, and/or sell copies of the Software, and to permit
+%% persons to whom the Software is furnished to do so, subject to the
+%% following conditions:
+%%
+%% The above copyright notice and this permission notice shall be included
+%% in all copies or substantial portions of the Software.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+%% OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+%% MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+%% NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+%% DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+%% OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+%% USE OR OTHER DEALINGS IN THE SOFTWARE.
+%% -------------------------------------------------------------------
+%%  @author Michael Coles <michael.coles@gmail.com>
+%%  @copyright (C) 2014, Darach Ennis, Michael Coles
+%%  @doc
+%%
+%%  @end
+%% -------------------------------------------------------------------
 -module(prop_eep).
 
 -include_lib("proper/include/proper.hrl").
@@ -11,7 +37,7 @@
 prop_avg_aggregate_accum() ->
     ?FORALL(Ints, non_empty(list(integer())),
             begin
-                {RealSum, RealCount, AggData} = 
+                {RealSum, RealCount, AggData} =
                     lists:foldl(
                       fun(N, {Sum, Count, State}) ->
                               {Sum+N, Count+1, eep_stats_avg:accumulate(State, N)}
@@ -24,7 +50,7 @@ prop_avg_aggregate_accum() ->
 prop_monotonic_clock_count() ->
     ?FORALL({Interval, Events},
             {pos_integer(), list(tick)},
-            begin 
+            begin
                Init = eep_clock_count:new(Interval),
                {Clock, Tocks} = lists:foldl(fun clock_handle/2,
                                             {Init, 0}, Events),

--- a/test/prop_eep.erl
+++ b/test/prop_eep.erl
@@ -54,7 +54,8 @@ prop_monotonic_clock_count() ->
                Init = eep_clock_count:new(Interval),
                {Clock, Tocks} = lists:foldl(fun clock_handle/2,
                                             {Init, 0}, Events),
-               length(Events) == eep_clock_count:at(Clock)
+               ExpectedTime = length(Events) - (length(Events) rem Interval),
+               eep_clock_count:at(Clock) == ExpectedTime
                     andalso Tocks == length(Events) div Interval
            end).
 

--- a/test/prop_eep.erl
+++ b/test/prop_eep.erl
@@ -1,0 +1,69 @@
+-module(prop_eep).
+
+-compile([export_all]).
+
+-include_lib("proper/include/proper.hrl").
+
+-export([prop_avg_aggregate_accum/0]).
+
+-define(epsilon, 1.0e-14).
+
+prop_avg_aggregate_accum() ->
+    ?FORALL(Ints, non_empty(list(integer())),
+            begin
+                {RealSum, RealCount, AggData} = 
+                    lists:foldl(
+                      fun(N, {Sum, Count, State}) ->
+                              {Sum+N, Count+1, eep_stats_avg:accumulate(State, N)}
+                      end, {0, 0, eep_stats_avg:init()}, Ints),
+                AggAvg = eep_stats_avg:emit(AggData),
+                RealAvg = RealSum / RealCount,
+                (AggAvg - RealAvg) < ?epsilon
+            end).
+
+prop_monotonic_clock_count() ->
+    ?FORALL({Interval, Events},
+            {pos_integer(), list(tick)},
+            begin 
+               Init = eep_clock_count:new(Interval),
+               {Clock, Tocks} = lists:foldl(fun clock_handle/2,
+                                            {Init, 0}, Events),
+               length(Events) == eep_clock_count:at(Clock)
+                    andalso Tocks == length(Events) div Interval
+           end).
+
+clock_handle(tick, {Clock, Tocks}) ->
+    case eep_clock_count:tick(Clock) of
+        {false, TickedClock} ->
+            {TickedClock, Tocks};
+        {true, TockingClock} ->
+            case eep_clock_count:tock(TockingClock, undefined) of
+                {true, Tocked} -> {Tocked, Tocks+1};
+                {false, Tocked} -> {Tocked, Tocks}
+            end
+    end;
+clock_handle(Event, _Clock) ->
+    error({unhandled_clock_event, Event}).
+
+prop_periodic_window() ->
+    ?FORALL(
+       {Agg, Clock, Interval, Events},
+       {eep_stats_count, eep_clock_count, pos_integer(),
+        list(oneof([tick, {push, 1}]))},
+       begin
+           Init = eep_window_periodic:new(Agg, Clock, fun(_) -> ok end, Interval),
+           {_Final, Results} = lists:foldl(fun window_handle/2,
+                                          {Init, []}, Events),
+           {Emissions, _} =
+               lists:partition(fun(emit) -> true; (_) -> false end, Results),
+           {Ticks, _Datapoints} =
+               lists:partition(fun(tick) -> true; (_) -> false end, Events),
+           length(Emissions) == (length(Ticks)) div Interval
+       end).
+
+window_handle({push, _}=Push, {Window, Results}) ->
+    {Act, Pushed} = eep_window_periodic:push(Window, Push),
+    {Pushed, Results ++ [Act]};
+window_handle(tick, {Window, Results}) ->
+    {Act, Ticked} = eep_window_periodic:tick(Window),
+    {Ticked, Results ++ [Act]}.

--- a/test/prop_eep.erl
+++ b/test/prop_eep.erl
@@ -1,10 +1,10 @@
 -module(prop_eep).
 
--compile([export_all]).
-
 -include_lib("proper/include/proper.hrl").
 
 -export([prop_avg_aggregate_accum/0]).
+-export([prop_monotonic_clock_count/0]).
+-export([prop_periodic_window/0]).
 
 -define(epsilon, 1.0e-14).
 


### PR DESCRIPTION
Headlines:
 - clock implementations now only differ by initial state and increment function - to be further refactored later
 - `eep_clock` behaviour now has `-callback` specs
 - added some rudimentary property tests for `eep_clock_count`, `eep_window_periodic` and `eep_stats_avg`

Plus a little bonus refactoring.