### PR TITLE
Refactor away from reptition

### DIFF
--- a/src/eep_clock.erl
+++ b/src/eep_clock.erl
@@ -28,6 +28,8 @@
 
 -include_lib("eep_erl.hrl").
 
+-export([tick/2]).
+
 -callback name() ->
     Name :: atom().
 -callback at(ck_state()) ->
@@ -40,3 +42,11 @@
     {Tocked :: boolean(), New :: ck_state()}.
 -callback tock(Old :: ck_state()) ->
     {Tocked :: boolean(), New :: ck_state()}.
+
+tick(CkMod, Clock) ->
+    case CkMod:tick(Clock) of
+        {false, UnTicked} -> {noop, UnTicked};
+        {true, Ticked} ->
+            {_, Tocked} = CkMod:tock(Ticked),
+            {tock, Tocked}
+    end.

--- a/src/eep_window.erl
+++ b/src/eep_window.erl
@@ -1,0 +1,65 @@
+%% -------------------------------------------------------------------
+%% Copyright (c) 2013 Darach Ennis < darach at gmail dot com > 
+%%
+%% Permission is hereby granted, free of charge, to any person obtaining a
+%% copy of this software and associated documentation files (the
+%% "Software"), to deal in the Software without restriction, including
+%% without limitation the rights to use, copy, modify, merge, publish,
+%% distribute, sublicense, and/or sell copies of the Software, and to permit
+%% persons to whom the Software is furnished to do so, subject to the
+%% following conditions:
+%%
+%% The above copyright notice and this permission notice shall be included
+%% in all copies or substantial portions of the Software.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+%% OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+%% MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+%% NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+%% DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+%% OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+%% USE OR OTHER DEALINGS IN THE SOFTWARE.
+%%
+%% File: eep_window.erl. Generic window-based functionality.
+%%
+%% -------------------------------------------------------------------
+-module(eep_window).
+
+-export([start/3]).
+-export([start/4]).
+
+-export([loop/3]).
+
+start(Window, AggMod, Interval) ->
+    start(Window, AggMod, eep_clock_wall, Interval).
+start(Window, AggMod, ClockMod, Interval) ->
+    {ok, EventPid } = gen_event:start_link(),
+    CallbackFun = fun(NewAggregate) ->
+        gen_event:notify(
+            EventPid,
+            {emit, AggMod:emit(NewAggregate)}
+        )
+    end,
+    State = Window:new(AggMod, ClockMod, CallbackFun, Interval),
+    spawn(?MODULE, loop, [Window, EventPid, State]).
+
+loop(Window, EventPid, State) ->
+  receive
+    tick ->
+      {_,NewState} = Window:tick(State),
+      loop(Window, EventPid, NewState);
+    { push, Event } ->
+      {_,NewState} = Window:push(State,Event),
+      loop(Window, EventPid, NewState);
+    { add_handler, Handler, Arr } ->
+      gen_event:add_handler(EventPid, Handler, Arr),
+      loop(Window, EventPid, State);
+    { delete_handler, Handler } ->
+      gen_event:delete_handler(EventPid, Handler, []),
+      loop(Window, EventPid, State);
+    stop ->
+      ok;
+    {debug, From} ->
+      From ! {debug, State},
+      loop(Window, EventPid, State)
+  end.

--- a/src/eep_window_monotonic.erl
+++ b/src/eep_window_monotonic.erl
@@ -32,6 +32,7 @@
 
 -include_lib("eep_erl.hrl").
 
+-export([start/3]).
 -export([new/4]).
 -export([new/5]).
 -export([tick/1]).
@@ -46,6 +47,9 @@
     aggregate :: any(),
     callback = undefined :: fun((...) -> any())
 }).
+
+start(Mod, ClockMod, Interval) ->
+    eep_window:start(?MODULE, Mod, ClockMod, Interval).
 
 -spec new(Mod::module(), ClockMod::module(), CallbackFun::fun((...) -> any()), Integer::integer()) -> #state{}.
 new(Mod, ClockMod, CallbackFun, Interval) ->

--- a/src/eep_window_monotonic.erl
+++ b/src/eep_window_monotonic.erl
@@ -1,5 +1,5 @@
 %% -------------------------------------------------------------------
-%% Copyright (c) 2013 Darach Ennis < darach at gmail dot com > 
+%% Copyright (c) 2013 Darach Ennis < darach at gmail dot com >
 %%
 %% Permission is hereby granted, free of charge, to any person obtaining a
 %% copy of this software and associated documentation files (the
@@ -32,7 +32,6 @@
 
 -include_lib("eep_erl.hrl").
 
--export([start/3]).
 -export([new/4]).
 -export([new/5]).
 -export([tick/1]).
@@ -47,26 +46,6 @@
     aggregate :: any(),
     callback = undefined :: fun((...) -> any())
 }).
-
-%%--------------------------------------------------------------------
-%% @doc
-%% Start the monotonic window with the given conflation module, Mod, the
-%% given clock module, ClockMod, and the given clock Interval.
-%% @end
-%%--------------------------------------------------------------------
-
--spec start(Mod::module(), ClockMod::module(), Interval::integer()) -> pid().
-
-start(Mod, ClockMod, Interval) ->
-    {ok, EventPid } = gen_event:start_link(),
-    CallbackFun = fun(NewAggregate) ->
-        gen_event:notify(
-            EventPid,
-            {emit, Mod:emit(NewAggregate)}
-        )
-    end,
-    State = ?MODULE:new(Mod, ClockMod, CallbackFun, Interval),
-    spawn(eep_window, loop, [?MODULE, EventPid, State]).
 
 -spec new(Mod::module(), ClockMod::module(), CallbackFun::fun((...) -> any()), Integer::integer()) -> #state{}.
 new(Mod, ClockMod, CallbackFun, Interval) ->

--- a/src/eep_window_periodic.erl
+++ b/src/eep_window_periodic.erl
@@ -28,6 +28,8 @@
 
 -include_lib("eep_erl.hrl").
 
+-export([start/2]).
+-export([start/3]).
 -export([new/3]).
 -export([new/4]).
 -export([new/5]).
@@ -43,6 +45,11 @@
     aggregate :: any(),
     callback = undefined :: fun((...) -> any())
 }).
+
+start(AggMod, Interval) ->
+    start(AggMod, eep_clock_wall, Interval).
+start(AggMod, ClockMod, Interval) ->
+    eep_window:start(?MODULE, AggMod, ClockMod, Interval).
 
 new(AggMod, CallbackFun, Interval) ->
     new(AggMod, eep_clock_wall, [], CallbackFun, Interval).

--- a/src/eep_window_periodic.erl
+++ b/src/eep_window_periodic.erl
@@ -68,7 +68,7 @@ accum(#state{agg_mod=AggMod, aggregate=Agg}=State,Event) ->
 tick(#state{callback=CallbackFun, agg_mod=AggMod, aggregate=Agg, seed=Seed,
             clock_mod=CkMod, clock=Clock}=State) ->
     case eep_clock:tick(CkMod, Clock) of
-        {noop, Clock} -> {noop, State#state{clock=Clock}};
+        {noop, Clock2} -> {noop, State#state{clock=Clock2}};
         {tock, Tocked} ->
             CallbackFun(Agg),
             {emit, State#state{aggregate=AggMod:init(Seed), clock=Tocked}}

--- a/src/eep_window_periodic.erl
+++ b/src/eep_window_periodic.erl
@@ -28,8 +28,6 @@
 
 -include_lib("eep_erl.hrl").
 
--export([start/2]).
--export([start/3]).
 -export([new/3]).
 -export([new/4]).
 -export([new/5]).
@@ -45,19 +43,6 @@
     aggregate :: any(),
     callback = undefined :: fun((...) -> any())
 }).
-
-start(AggMod, Interval) ->
-    start(AggMod, eep_clock_wall, Interval).
-start(AggMod, ClockMod, Interval) ->
-    {ok, EventPid } = gen_event:start_link(),
-    CallbackFun = fun(NewAggregate) ->
-        gen_event:notify(
-            EventPid,
-            {emit, AggMod:emit(NewAggregate)}
-        )
-    end,
-    State = new(AggMod, ClockMod, CallbackFun, Interval),
-    spawn(eep_window, loop, [?MODULE, EventPid, State]).
 
 new(AggMod, CallbackFun, Interval) ->
     new(AggMod, eep_clock_wall, [], CallbackFun, Interval).

--- a/src/eep_window_sliding.erl
+++ b/src/eep_window_sliding.erl
@@ -62,7 +62,6 @@ new(Mod, CallbackFun, Size) ->
 new(Mod, Seed, CallbackFun, Size) ->
     #state{size=Size, seed=Seed, mod=Mod, callback=CallbackFun, aggregate=Mod:init(Seed)}.
 
-
 push(State, Event) ->
     slide(State, Event).
 
@@ -72,6 +71,10 @@ slide(#state{mod=Mod, size=Size, aggregate=Aggregate,count=Count,callback=Callba
         Count < Size ->
             NewPrior = Prior ++ [Event],
             {noop,State#state{aggregate=NewAggregate,count=Count+1,prior=NewPrior}};
+        Count == Size ->
+            NewPrior = Prior ++ [Event],
+            CallbackFun(NewAggregate),
+            {emit, State#state{aggregate=NewAggregate,count=Count+1,prior=NewPrior}};
         true ->
             [Value | PriorTl] = Prior,
             NewAggregate2 = Mod:compensate(NewAggregate, Value),

--- a/src/eep_window_sliding.erl
+++ b/src/eep_window_sliding.erl
@@ -1,5 +1,5 @@
 %% -------------------------------------------------------------------
-%% Copyright (c) 2013 Darach Ennis < darach at gmail dot com > 
+%% Copyright (c) 2013 Darach Ennis < darach at gmail dot com >
 %%
 %% Permission is hereby granted, free of charge, to any person obtaining a
 %% copy of this software and associated documentation files (the
@@ -33,9 +33,6 @@
 -export([new/4]).
 -export([push/2]).
 
-%% private.
--export([loop/1]).
-
 -record(state, {
     size :: integer(),
     mod :: module(),
@@ -43,19 +40,19 @@
     aggregate :: any(),
     callback = undefined :: fun((...) -> any()),
     count = 1 :: integer(),
-    pid :: pid(),
     prior = [] :: list()
 }).
 
 start(Mod, Size) ->
   {ok, EventPid } = gen_event:start_link(),
-  CallbackFun = fun(NewAggregate) -> 
+  CallbackFun = fun(NewAggregate) ->
       gen_event:notify(
           EventPid,
           {emit, Mod:emit(NewAggregate)}
       )
   end,
-  spawn(?MODULE, loop, [#state{mod=Mod, seed=[], size=Size, pid=EventPid, count=1, aggregate=Mod:init(), callback=CallbackFun}]).
+  State = new(Mod, CallbackFun, Size),
+  spawn(eep_window, loop, [?MODULE, EventPid, State]).
 
 -spec new(Mod::module(), CallbackFun::fun((...) -> any()), Size::integer()) -> #state{}.
 new(Mod, CallbackFun, Size) ->
@@ -69,39 +66,20 @@ new(Mod, Seed, CallbackFun, Size) ->
 push(State, Event) ->
     slide(State, Event).
 
--spec loop(State::#state{}) -> ok.
-loop(#state{pid=EventPid}=State) ->
-  receive
-    { push, Event } ->
-        {_,NewState} = slide(State,Event),
-        loop(NewState);
-    { add_handler, Handler, Arr } ->
-        gen_event:add_handler(EventPid, Handler, Arr),
-        loop(State);
-    { delete_handler, Handler } ->
-        gen_event:delete_handler(EventPid, Handler, []),
-        loop(State);
-    stop ->
-      ok;
-    {debug, From} ->
-      From ! {debug, State},
-      loop(State)
-  end.
-
 slide(#state{mod=Mod, size=Size, aggregate=Aggregate,count=Count,callback=CallbackFun,prior=Prior}=State,Event) ->
     NewAggregate = Mod:accumulate(Aggregate, Event),
-    if 
+    if
         Count < Size ->
             NewPrior = Prior ++ [Event],
             {noop,State#state{aggregate=NewAggregate,count=Count+1,prior=NewPrior}};
         Count == Size ->
             NewPrior = Prior ++ [Event],
-            CallbackFun(NewAggregate), 
+            CallbackFun(NewAggregate),
             {emit,State#state{aggregate=NewAggregate,count=Count+1,prior=NewPrior}};
         true ->
             Value = lists:nth(1,Prior),
             NewAggregate2 = Mod:compensate(NewAggregate, Value),
-            CallbackFun(NewAggregate2), 
+            CallbackFun(NewAggregate2),
             NewPrior = erlang:tl(Prior) ++ [Event],
             {emit,State#state{aggregate=NewAggregate2,count=Count+1,prior=NewPrior}}
     end.

--- a/src/eep_window_sliding.erl
+++ b/src/eep_window_sliding.erl
@@ -72,14 +72,10 @@ slide(#state{mod=Mod, size=Size, aggregate=Aggregate,count=Count,callback=Callba
         Count < Size ->
             NewPrior = Prior ++ [Event],
             {noop,State#state{aggregate=NewAggregate,count=Count+1,prior=NewPrior}};
-        Count == Size ->
-            NewPrior = Prior ++ [Event],
-            CallbackFun(NewAggregate),
-            {emit,State#state{aggregate=NewAggregate,count=Count+1,prior=NewPrior}};
         true ->
-            Value = lists:nth(1,Prior),
+            [Value | PriorTl] = Prior,
             NewAggregate2 = Mod:compensate(NewAggregate, Value),
             CallbackFun(NewAggregate2),
-            NewPrior = erlang:tl(Prior) ++ [Event],
+            NewPrior = PriorTl ++ [Event],
             {emit,State#state{aggregate=NewAggregate2,count=Count+1,prior=NewPrior}}
     end.

--- a/test/eep_erl_SUITE.erl
+++ b/test/eep_erl_SUITE.erl
@@ -293,7 +293,7 @@ t_win_monotonic_inline(_Config) ->
     ok.
 
 t_win_monotonic_process(_config) ->
-    Pid = eep_window:start(eep_window_monotonic, eep_stats_count, eep_clock_count, 0),
+    Pid = eep_window_monotonic:start(eep_stats_count, eep_clock_count, 0),
     Pid ! {push, foo},
     Pid ! {push, bar},
     Pid ! {debug, self()},

--- a/test/eep_erl_SUITE.erl
+++ b/test/eep_erl_SUITE.erl
@@ -333,4 +333,4 @@ t_monotonic_clock_count(_) ->
     ?proptest(prop_eep:prop_monotonic_clock_count()).
 
 t_periodic_window(_) ->
-    ?proptest(prop_eep:prop_monotonic_clock_count()).
+    ?proptest(prop_eep:prop_periodic_window()).

--- a/test/eep_erl_SUITE.erl
+++ b/test/eep_erl_SUITE.erl
@@ -43,7 +43,9 @@
 -export([t_win_monotonic_process/1]).
 -export([t_seedable_aggregate/1]).
 -export([t_avg_aggregate_accum/1]).
+-export([t_sum_aggregate_accum/1]).
 -export([t_monotonic_clock_count/1]).
+-export([t_monotonic_sliding_window/1]).
 -export([t_periodic_window/1]).
 
 -include("eep_erl.hrl").
@@ -93,7 +95,9 @@ groups() ->
             ]},
         {props, [], [
             t_avg_aggregate_accum,
+            t_sum_aggregate_accum,
             t_monotonic_clock_count,
+            t_monotonic_sliding_window,
             t_periodic_window
             ]}
     ].
@@ -329,8 +333,14 @@ t_seedable_aggregate(_Config) ->
 t_avg_aggregate_accum(_) ->
     ?proptest(prop_eep:prop_avg_aggregate_accum()).
 
+t_sum_aggregate_accum(_) ->
+    ?proptest(prop_eep:prop_sum_aggregate_accum()).
+
 t_monotonic_clock_count(_) ->
     ?proptest(prop_eep:prop_monotonic_clock_count()).
 
 t_periodic_window(_) ->
     ?proptest(prop_eep:prop_periodic_window()).
+
+t_monotonic_sliding_window(_) ->
+    ?proptest(prop_eep:prop_monotonic_sliding_window()).

--- a/test/eep_erl_SUITE.erl
+++ b/test/eep_erl_SUITE.erl
@@ -242,7 +242,7 @@ t_win_periodic_inline(_Config) ->
     ok.
 
 t_win_periodic_process(_Config) ->
-  Pid = eep_window_periodic:start(eep_stats_count, 0),
+  Pid = eep_window:start(eep_window_periodic, eep_stats_count, 0),
   Pid ! {push, foo},
   Pid ! {push, bar},
   Pid ! {debug, self()},
@@ -289,7 +289,7 @@ t_win_monotonic_inline(_Config) ->
     ok.
 
 t_win_monotonic_process(_config) ->
-    Pid = eep_window_monotonic:start(eep_stats_count, eep_clock_count, 0),
+    Pid = eep_window:start(eep_window_monotonic, eep_stats_count, eep_clock_count, 0),
     Pid ! {push, foo},
     Pid ! {push, bar},
     Pid ! {debug, self()},

--- a/test/eep_erl_SUITE.erl
+++ b/test/eep_erl_SUITE.erl
@@ -246,7 +246,7 @@ t_win_periodic_inline(_Config) ->
     ok.
 
 t_win_periodic_process(_Config) ->
-  Pid = eep_window:start(eep_window_periodic, eep_stats_count, 0),
+  Pid = eep_window_periodic:start(eep_stats_count, 0),
   Pid ! {push, foo},
   Pid ! {push, bar},
   Pid ! {debug, self()},

--- a/test/eep_erl_SUITE.erl
+++ b/test/eep_erl_SUITE.erl
@@ -184,16 +184,16 @@ t_win_sliding_inline(_Config) ->
     W0 = eep_window_sliding:new(eep_stats_count, fun(_) -> boop end, 2),
     {noop,W1} = eep_window_sliding:push(W0,foo),
     {emit,W2} = eep_window_sliding:push(W1,bar),
-    {state,2,eep_stats_count,[],2,_,3,_,[foo,bar]} = W2,
+    {state,2,eep_stats_count,[],2,_,3,[foo,bar]} = W2,
     {emit,W3} = eep_window_sliding:push(W2,baz),
-    {state,2,eep_stats_count,[],2,_,4,_,[bar,baz]} = W3,
+    {state,2,eep_stats_count,[],2,_,4,[bar,baz]} = W3,
     {emit,W4} = eep_window_sliding:push(W3,foo),
     {emit,W5} = eep_window_sliding:push(W4,bar),
     {emit,W6} = eep_window_sliding:push(W5,foo),
     {emit,W7} = eep_window_sliding:push(W6,bar),
     {emit,W8} = eep_window_sliding:push(W7,foo),
     {emit,W9} = eep_window_sliding:push(W8,bar),
-    {state,2,eep_stats_count,[],2,_,10,_,[foo,bar]} = W9.
+    {state,2,eep_stats_count,[],2,_,10,[foo,bar]} = W9.
 
 t_win_sliding_process(_Config) ->
     Pid = eep_window_sliding:start(eep_stats_count, 2),
@@ -201,12 +201,12 @@ t_win_sliding_process(_Config) ->
     Pid ! {push, bar},
     Pid ! {debug, self()},
     receive
-        { debug, Debug0 } -> {state,2,eep_stats_count,[],2,_,3,_,[foo,bar]} = Debug0
+        { debug, Debug0 } -> {state,2,eep_stats_count,[],2,_,3,[foo,bar]} = Debug0
     end,
     Pid ! {push, baz},
     Pid ! {debug, self()},
     receive
-        { debug, Debug1 } -> {state,2,eep_stats_count,[],2,_,4,_,[bar,baz]} = Debug1
+        { debug, Debug1 } -> {state,2,eep_stats_count,[],2,_,4,[bar,baz]} = Debug1
     end,
     Pid ! {push, foo},
     Pid ! {push, bar},
@@ -216,11 +216,11 @@ t_win_sliding_process(_Config) ->
     Pid ! {push, bar},
     Pid ! {debug, self()},
     receive
-        { debug, Debug2 } -> {state,2,eep_stats_count,[],2,_,10,_,[foo,bar]} = Debug2
+        { debug, Debug2 } -> {state,2,eep_stats_count,[],2,_,10,[foo,bar]} = Debug2
     end,
     Pid ! {debug, self()},
     receive
-        { debug, Debug3 } -> {state,2,eep_stats_count,[],2,_,10,_,[foo,bar]} = Debug3
+        { debug, Debug3 } -> {state,2,eep_stats_count,[],2,_,10,[foo,bar]} = Debug3
     end,
     Pid ! stop.
 

--- a/test/eep_erl_SUITE.erl
+++ b/test/eep_erl_SUITE.erl
@@ -228,9 +228,9 @@ t_win_periodic_inline(_Config) ->
     W0 = eep_window_periodic:new(eep_stats_count, fun(_) -> boop end, 0),
     {noop,W1} = eep_window_periodic:push(W0,foo),
     {noop,W2} = eep_window_periodic:push(W1,bar),
-    {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},2,_,undefined} = W2,
+    {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},2,_} = W2,
     {emit,W3} = eep_window_periodic:tick(W2),
-    {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_,undefined} = W3,
+    {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_} = W3,
     {noop,W4} = eep_window_periodic:push(W3,foo),
     {noop,W5} = eep_window_periodic:push(W4,bar),
     {noop,W6} = eep_window_periodic:push(W5,foo),
@@ -238,7 +238,7 @@ t_win_periodic_inline(_Config) ->
     {noop,W8} = eep_window_periodic:push(W7,foo),
     {noop,W9} = eep_window_periodic:push(W8,bar),
     {emit,W10} = eep_window_periodic:tick(W9),
-    {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_,undefined} = W10,
+    {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_} = W10,
     ok.
 
 t_win_periodic_process(_Config) ->
@@ -247,12 +247,12 @@ t_win_periodic_process(_Config) ->
   Pid ! {push, bar},
   Pid ! {debug, self()},
   receive
-    { debug, Debug0 } -> {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},2,_,_} = Debug0
+    { debug, Debug0 } -> {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},2,_} = Debug0
   end,
   Pid ! tick,
   Pid ! {debug, self()},
   receive
-    { debug, Debug1 } -> {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_,_} = Debug1
+    { debug, Debug1 } -> {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_} = Debug1
   end,
   Pid ! {push, foo},
   Pid ! {push, bar},
@@ -262,12 +262,12 @@ t_win_periodic_process(_Config) ->
   Pid ! {push, bar},
   Pid ! {debug, self()},
   receive
-    { debug, Debug2 } -> {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},6,_,_} = Debug2
+    { debug, Debug2 } -> {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},6,_} = Debug2
   end,
   Pid ! tick,
   Pid ! {debug, self()},
   receive
-    { debug, Debug3 } -> {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_,_} = Debug3
+    { debug, Debug3 } -> {state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_} = Debug3
   end,
   Pid ! stop.
 
@@ -275,9 +275,9 @@ t_win_monotonic_inline(_Config) ->
     W0 = eep_window_monotonic:new(eep_stats_count, eep_clock_count, fun(_) -> boop end, 0),
     {noop,W1} = eep_window_monotonic:push(W0,foo),
     {noop,W2} = eep_window_monotonic:push(W1,bar),
-    {state,undefined,eep_stats_count,[],eep_clock_count,{eep_clock,3,0,0},2,_,undefined} = W2,
+    {state,undefined,eep_stats_count,[],eep_clock_count,{eep_clock,3,0,0},2,_} = W2,
     {emit,W3} = eep_window_monotonic:tick(W2),
-    {state,undefined,eep_stats_count,[],eep_clock_count,{eep_clock,_,_,0},0,_,undefined} = W3,
+    {state,undefined,eep_stats_count,[],eep_clock_count,{eep_clock,_,_,0},0,_} = W3,
     {noop,W4} = eep_window_monotonic:push(W3,foo),
     {noop,W5} = eep_window_monotonic:push(W4,bar),
     {noop,W6} = eep_window_monotonic:push(W5,foo),
@@ -285,7 +285,7 @@ t_win_monotonic_inline(_Config) ->
     {noop,W8} = eep_window_monotonic:push(W7,foo),
     {noop,W9} = eep_window_monotonic:push(W8,bar),
     {emit,W10} = eep_window_monotonic:tick(W9),
-    {state,undefined,eep_stats_count,[],eep_clock_count,{eep_clock,_,_,0},0,_,undefined} = W10,
+    {state,undefined,eep_stats_count,[],eep_clock_count,{eep_clock,_,_,0},0,_} = W10,
     ok.
 
 t_win_monotonic_process(_config) ->
@@ -294,12 +294,12 @@ t_win_monotonic_process(_config) ->
     Pid ! {push, bar},
     Pid ! {debug, self()},
     receive
-    { debug, Debug0 } -> {state,undefined,eep_stats_count,[],eep_clock_count, {eep_clock,3,0,0},2,_,_}  = Debug0
+    { debug, Debug0 } -> {state,undefined,eep_stats_count,[],eep_clock_count, {eep_clock,3,0,0},2,_}  = Debug0
     end,
     Pid ! tick,
     Pid ! {debug, self()},
     receive
-    { debug, Debug1 } -> {state,undefined,eep_stats_count,[],eep_clock_count, {eep_clock,4,0,0},0,_,_}  = Debug1
+    { debug, Debug1 } -> {state,undefined,eep_stats_count,[],eep_clock_count, {eep_clock,4,0,0},0,_}  = Debug1
     end,
     Pid ! {push, foo},
     Pid ! {push, bar},
@@ -309,12 +309,12 @@ t_win_monotonic_process(_config) ->
     Pid ! {push, bar},
     Pid ! {debug, self()},
     receive
-    { debug, Debug2 } -> {state,undefined,eep_stats_count,[],eep_clock_count, {eep_clock,10,0,0},6,_,_}  = Debug2
+    { debug, Debug2 } -> {state,undefined,eep_stats_count,[],eep_clock_count, {eep_clock,10,0,0},6,_}  = Debug2
     end,
     Pid ! tick,
     Pid ! {debug, self()},
     receive
-    { debug, Debug3 } -> {state,undefined,eep_stats_count,[],eep_clock_count, {eep_clock,11,0,0},0,_,_}  = Debug3
+    { debug, Debug3 } -> {state,undefined,eep_stats_count,[],eep_clock_count, {eep_clock,11,0,0},0,_}  = Debug3
     end,
     Pid ! stop.
 

--- a/test/eep_erl_SUITE.erl
+++ b/test/eep_erl_SUITE.erl
@@ -134,21 +134,21 @@ t_clock_count(_Config) ->
 
 t_win_tumbling_inline(_Config) ->
     W0  = eep_window_tumbling:new(eep_stats_count, fun(_Callback) -> boop end, 2),
-    {state,2,eep_stats_count,[],0,_,1,undefined} = W0,
+    {state,2,eep_stats_count,[],0,_,1} = W0,
     {noop,W1} = eep_window_tumbling:push(W0,foo),
     {emit,W2} = eep_window_tumbling:push(W1,bar),
     {noop,W3} = eep_window_tumbling:push(W2,baz),
     {emit,W4} = eep_window_tumbling:push(W3,bar),
-    {state,2,eep_stats_count,[],0,_,1,undefined} = W4,
+    {state,2,eep_stats_count,[],0,_,1} = W4,
     {noop,W5} = eep_window_tumbling:push(W4,foo),
-    {state,2,eep_stats_count,[],1,_,2,undefined} = W5,
+    {state,2,eep_stats_count,[],1,_,2} = W5,
     {emit,W6} = eep_window_tumbling:push(W5,bar),
     {noop,W7} = eep_window_tumbling:push(W6,foo),
     {emit,W8} = eep_window_tumbling:push(W7,bar),
     {noop,W9} = eep_window_tumbling:push(W8,foo),
-    {state,2,eep_stats_count,[],0,_,1,undefined} = W8,
+    {state,2,eep_stats_count,[],0,_,1} = W8,
     {emit,W10} = eep_window_tumbling:push(W9,bar),
-    {state,2,eep_stats_count,[],0,_,1,undefined} = W10,
+    {state,2,eep_stats_count,[],0,_,1} = W10,
     ok.
 
 t_win_tumbling_process(_Config) ->
@@ -157,12 +157,12 @@ t_win_tumbling_process(_Config) ->
     Pid ! {push, bar},
     Pid ! {debug, self()},
     receive
-	    { debug, Debug0 } -> {state, 2, eep_stats_count, [], 0, _, 1, _} = Debug0
+	    { debug, Debug0 } -> {state, 2, eep_stats_count, [], 0, _, 1} = Debug0
     end,
     Pid ! {push, baz},
     Pid ! {debug, self()},
     receive
-	    { debug, Debug1 } -> {state, 2, eep_stats_count, [], 1, _, 2, _} = Debug1
+	    { debug, Debug1 } -> {state, 2, eep_stats_count, [], 1, _, 2} = Debug1
     end,
     Pid ! {push, foo},
     Pid ! {push, bar},
@@ -172,11 +172,11 @@ t_win_tumbling_process(_Config) ->
     Pid ! {push, bar},
     Pid ! {debug, self()},
     receive
-	    { debug, Debug2 } -> {state, 2, eep_stats_count, [], 1, _, 2, _} = Debug2
+	    { debug, Debug2 } -> {state, 2, eep_stats_count, [], 1, _, 2} = Debug2
     end,
     Pid ! {debug, self()},
     receive
-	    { debug, Debug3 } -> {state, 2, eep_stats_count, [], 1, _, 2, _} = Debug3
+	    { debug, Debug3 } -> {state, 2, eep_stats_count, [], 1, _, 2} = Debug3
     end,
     Pid ! stop.
 

--- a/test/prop_eep.erl
+++ b/test/prop_eep.erl
@@ -29,7 +29,9 @@
 -include_lib("proper/include/proper.hrl").
 
 -export([prop_avg_aggregate_accum/0]).
+-export([prop_sum_aggregate_accum/0]).
 -export([prop_monotonic_clock_count/0]).
+-export([prop_monotonic_sliding_window/0]).
 -export([prop_periodic_window/0]).
 
 -define(epsilon, 1.0e-14).
@@ -45,6 +47,17 @@ prop_avg_aggregate_accum() ->
                 AggAvg = eep_stats_avg:emit(AggData),
                 RealAvg = RealSum / RealCount,
                 (AggAvg - RealAvg) < ?epsilon
+            end).
+
+prop_sum_aggregate_accum() ->
+    ?FORALL(Ints, non_empty(list(integer())),
+            begin
+                {RealSum, AggData} =
+                    lists:foldl(
+                      fun(N, {Sum, State}) ->
+                              {Sum+N, eep_stats_sum:accumulate(State, N)}
+                      end, {0, eep_stats_sum:init()}, Ints),
+                    RealSum == eep_stats_sum:emit(AggData)
             end).
 
 prop_monotonic_clock_count() ->
@@ -94,3 +107,38 @@ window_handle({push, _}=Push, {Window, Results}) ->
 window_handle(tick, {Window, Results}) ->
     {Act, Ticked} = eep_window_periodic:tick(Window),
     {Ticked, Results ++ [Act]}.
+
+prop_monotonic_sliding_window() ->
+    ?FORALL({Size, Integers}, {pos_integer(), non_empty(list(integer()))},
+            begin
+                Win = {eep_stats_sum:init(), Size, 0, [], none},
+                %% TODO Refactor eep_window_sliding so we can use it directly here
+                %% and not replicate its inner machinations below.
+                WinFinal = lists:foldl(fun slide/2, Win, Integers),
+                {_, Size, _, _, Emission} = WinFinal,
+                if
+                    % We expect no emission if the input list is less than our window size
+                    Size >= length(Integers) -> Emission == none;
+                    Size < length(Integers) ->
+                        %% If Size is smaller than the number of input integers,
+                        %% the accumulated value will only be the sum of the
+                        %% last Size integers.
+                        Include = lists:sublist(lists:reverse(Integers), 1, Size),
+                        RealSum = lists:sum(Include),
+                        Emission == RealSum
+                end
+            end).
+
+%% NB This logic is copied directly from eep_window_sliding.erl
+slide(Int, {Agg, Size, Count, Prior, LastEmission}) ->
+    NewAgg = eep_stats_sum:accumulate(Agg, Int),
+    if
+        Count < Size ->
+            NewPrior = Prior ++ [Int],
+            {NewAgg, Size, Count+1, NewPrior, LastEmission};
+        true ->
+            [Value | Tail] = Prior,
+            NewAgg2 = eep_stats_sum:compensate(NewAgg, Value),
+            NewPrior = Tail ++ [Int],
+            {NewAgg2, Size, Count+1, NewPrior, eep_stats_sum:emit(NewAgg2)}
+    end.


### PR DESCRIPTION
 - Remove the individual `loop/1` functions from each window module, introducing instead `eep_window:loop/3`.
 - Move the actual body of `Win:start/n` into `eep_window:start/4` and replace the per-window-module implementations with a simple call to this.
 - Move the tick-tock wrapping logic into `eep_clock:tick/2` and leave only the reaction to the mechanism in the window implementations.
 - Introduce a little more PBT:
  - `eep_stats_sum:accumulate/2`
  - Sliding window logic (currently manually copied from `eep_window_sliding`)