### PR TITLE
Sliding time windows

### DIFF
--- a/include/eep_erl.hrl
+++ b/include/eep_erl.hrl
@@ -28,8 +28,9 @@
 
 -record(eep_clock,
         {
-         at = undefined :: integer() | undefined,
-         mark = undefined :: integer() | undefined,
+         origin = 0 :: integer(),
+         at   :: integer() | undefined,
+         mark :: integer() | undefined,
          interval = 1 :: integer()
         }).
 
@@ -38,6 +39,7 @@
          type :: tumbling | sliding,
          by :: event | ticks,
          compensating :: boolean(),
+         active :: boolean(),
          size :: pos_integer(),
          aggmod :: module(),
          agg :: any(),

--- a/src/eep_clock.erl
+++ b/src/eep_clock.erl
@@ -28,16 +28,25 @@
 
 -include_lib("eep_erl.hrl").
 
+-export([at/1]).
+-export([elapsed/1]).
 -export([tick/2]).
 
 -callback name() ->
     Name :: atom().
--callback at(ck_state()) ->
-    Now :: integer().
 -callback new(Interval :: integer()) ->
     ck_state().
 -callback inc(Old :: ck_state()) ->
     New :: ck_state().
+
+-spec at(ck_state()) ->
+    Now :: integer().
+at(#eep_clock{at=At}) -> At.
+
+-spec elapsed(ck_state()) ->
+    Now :: integer().
+elapsed(#eep_clock{origin=Origin, at=At}) ->
+    At - Origin.
 
 -spec tick(module(), Curr :: ck_state()) ->
     {noop, UnTicked :: ck_state()}

--- a/src/eep_clock.erl
+++ b/src/eep_clock.erl
@@ -38,8 +38,6 @@
     ck_state().
 -callback inc(Old :: ck_state()) ->
     New :: ck_state().
--callback tock(Old :: ck_state()) ->
-    {Tocked :: boolean(), New :: ck_state()}.
 
 -spec tick(module(), Curr :: ck_state()) ->
     {noop, UnTicked :: ck_state()}
@@ -48,7 +46,14 @@ tick(CkMod, Clock0) ->
     Clock1 = CkMod:inc(Clock0),
     #eep_clock{at=At, mark=Mark, interval=Interval}=Clock1,
     if (At - Mark) >= Interval ->
-           {_, Tocked} = CkMod:tock(Clock1),
+           {_, Tocked} = tock(Clock1),
            {tock, Tocked};
        true -> {noop, Clock1}
     end.
+
+tock(Clock0) ->
+  Delta = Clock0#eep_clock.at - Clock0#eep_clock.mark,
+  case Delta >= Clock0#eep_clock.interval of
+    true -> {true, Clock0#eep_clock{mark = Clock0#eep_clock.mark + Clock0#eep_clock.interval}};
+    false -> {false, Clock0}
+  end.

--- a/src/eep_clock.erl
+++ b/src/eep_clock.erl
@@ -38,18 +38,17 @@
     ck_state().
 -callback inc(Old :: ck_state()) ->
     New :: ck_state().
--callback tick(Old :: ck_state()) ->
-    {Tocked :: boolean(), New :: ck_state()}.
 -callback tock(Old :: ck_state()) ->
     {Tocked :: boolean(), New :: ck_state()}.
 
 -spec tick(module(), Curr :: ck_state()) ->
     {noop, UnTicked :: ck_state()}
     | {tock, Tocked :: ck_state()}.
-tick(CkMod, Clock) ->
-    case CkMod:tick(Clock) of
-        {false, UnTicked} -> {noop, UnTicked};
-        {true, Ticked} ->
-            {_, Tocked} = CkMod:tock(Ticked),
-            {tock, Tocked}
+tick(CkMod, Clock0) ->
+    Clock1 = CkMod:inc(Clock0),
+    #eep_clock{at=At, mark=Mark, interval=Interval}=Clock1,
+    if (At - Mark) >= Interval ->
+           {_, Tocked} = CkMod:tock(Clock1),
+           {tock, Tocked};
+       true -> {noop, Clock1}
     end.

--- a/src/eep_clock_count.erl
+++ b/src/eep_clock_count.erl
@@ -35,7 +35,6 @@
 -export([at/1]).
 -export([new/1]).
 -export([inc/1]).
--export([tick/1]).
 -export([tock/1]).
 
 name() -> count.
@@ -48,10 +47,6 @@ new(Interval) ->
 
 inc(State) -> 
   State#eep_clock{at = State#eep_clock.at + 1}.
-
-tick(State) ->
-  NewState = inc(State),
-  {(NewState#eep_clock.at - NewState#eep_clock.mark) >= NewState#eep_clock.interval, NewState}.
 
 tock(State) ->
   Delta = State#eep_clock.at - State#eep_clock.mark,

--- a/src/eep_clock_count.erl
+++ b/src/eep_clock_count.erl
@@ -41,7 +41,7 @@
 name() -> count.
 
 at(State) -> 
- State#eep_clock.mark.
+ State#eep_clock.at.
 
 new(Interval) ->
   #eep_clock{at = 0, mark = 0, interval = Interval}.
@@ -54,9 +54,8 @@ tick(State) ->
   {(NewState#eep_clock.at - NewState#eep_clock.mark) >= NewState#eep_clock.interval, NewState}.
 
 tock(State) ->
-    #eep_clock{mark=Mark, interval=Interval} = State,
-    Delta = State#eep_clock.at,
-    case Delta >= State#eep_clock.interval of
-        true -> {true, State#eep_clock{mark = (Mark + Interval)}};
-        false -> {false, State}
-    end.
+  Delta = State#eep_clock.at - State#eep_clock.mark,
+  case Delta >= State#eep_clock.interval of
+    true -> {true, State#eep_clock{mark = State#eep_clock.mark + State#eep_clock.interval}};
+    false -> {false, State}
+  end.

--- a/src/eep_clock_count.erl
+++ b/src/eep_clock_count.erl
@@ -35,7 +35,6 @@
 -export([at/1]).
 -export([new/1]).
 -export([inc/1]).
--export([tock/1]).
 
 name() -> count.
 
@@ -47,10 +46,3 @@ new(Interval) ->
 
 inc(State) -> 
   State#eep_clock{at = State#eep_clock.at + 1}.
-
-tock(State) ->
-  Delta = State#eep_clock.at - State#eep_clock.mark,
-  case Delta >= State#eep_clock.interval of
-    true -> {true, State#eep_clock{mark = State#eep_clock.mark + State#eep_clock.interval}};
-    false -> {false, State}
-  end.

--- a/src/eep_clock_count.erl
+++ b/src/eep_clock_count.erl
@@ -32,17 +32,13 @@
 
 %% clock behaviour.
 -export([name/0]).
--export([at/1]).
 -export([new/1]).
 -export([inc/1]).
 
 name() -> count.
 
-at(State) -> 
- State#eep_clock.at.
-
 new(Interval) ->
-  #eep_clock{at = 0, mark = 0, interval = Interval}.
+  #eep_clock{origin = 0, at = 0, mark = 0, interval = Interval}.
 
 inc(State) -> 
   State#eep_clock{at = State#eep_clock.at + 1}.

--- a/src/eep_clock_wall.erl
+++ b/src/eep_clock_wall.erl
@@ -33,7 +33,6 @@
 
 %% clock behaviour.
 -export([name/0]).
--export([at/1]).
 -export([new/1]).
 -export([inc/1]).
 
@@ -42,13 +41,10 @@
 
 name() -> crock.
 
-at(State) -> 
- State#eep_clock.at.
-
 new(Interval) ->
   At = ts(),
   Mark = At,
-  #eep_clock{at = At, interval = Interval, mark=Mark}.
+  #eep_clock{origin = At, at = At, interval = Interval, mark=Mark}.
 
 inc(State) -> 
   State#eep_clock{at = ts()}.

--- a/src/eep_clock_wall.erl
+++ b/src/eep_clock_wall.erl
@@ -36,7 +36,6 @@
 -export([at/1]).
 -export([new/1]).
 -export([inc/1]).
--export([tock/1]).
 
 %% impl
 -export([ts/0]).
@@ -53,13 +52,6 @@ new(Interval) ->
 
 inc(State) -> 
   State#eep_clock{at = ts()}.
-
-tock(State) ->
-  Delta = State#eep_clock.at - State#eep_clock.mark,
-  case Delta >= State#eep_clock.interval of
-    true -> {true, State#eep_clock{mark = State#eep_clock.mark + State#eep_clock.interval}};
-    false -> {false, State}
-  end.
 
 ts() ->
   {MegaSecs,Secs,MicroSecs} = erlang:now(),

--- a/src/eep_clock_wall.erl
+++ b/src/eep_clock_wall.erl
@@ -45,7 +45,7 @@
 name() -> crock.
 
 at(State) -> 
- State#eep_clock.mark.
+ State#eep_clock.at.
 
 new(Interval) ->
   At = ts(),

--- a/src/eep_clock_wall.erl
+++ b/src/eep_clock_wall.erl
@@ -36,7 +36,6 @@
 -export([at/1]).
 -export([new/1]).
 -export([inc/1]).
--export([tick/1]).
 -export([tock/1]).
 
 %% impl
@@ -54,11 +53,6 @@ new(Interval) ->
 
 inc(State) -> 
   State#eep_clock{at = ts()}.
-
-tick(State) ->
-  NewState = inc(State),
-  #eep_clock{at=At, mark=Mark, interval=Interval}=NewState,
-  {(At - Mark) >= Interval, NewState}.
 
 tock(State) ->
   Delta = State#eep_clock.at - State#eep_clock.mark,

--- a/src/eep_window.erl
+++ b/src/eep_window.erl
@@ -35,7 +35,7 @@
 -export([tick/1]).
 
 %% DEBUG
--export([accumulate/2, compensate/1, decide/2, decide/3, tick_/1]).
+-export([accumulate/2, compensate/1, reset/1, decide/2, decide/3, tick_/1]).
 
 -include("eep_erl.hrl").
 
@@ -98,9 +98,10 @@ accumulate(Event, #eep_win{aggmod=AMod, agg=Agg, count=Count, log=Log}=Win) ->
            Accumed
     end.
 
-compensate(#eep_win{compensating=false}=Win) ->
+reset(#eep_win{compensating=false}=Win) ->
     #eep_win{aggmod=AMod, seed=Seed}=Win,
-    Win#eep_win{agg=(AMod:init(Seed)), count=1};
+    Win#eep_win{agg=(AMod:init(Seed)), count=1}.
+
 compensate(#eep_win{compensating=true}=Win) ->
     #eep_win{aggmod=AMod, agg=Agg, size=S, log=Log, clockmod=CM, clock=C}=Win,
     At = CM:at(C),
@@ -129,7 +130,7 @@ decide([ emit |Actions], #eep_win{count=C, size=S}=Window, noop)
     decide(Actions, Window, noop);
 decide([ emit |Actions], #eep_win{}=Window, noop) ->
     %% TODO This enforces only one emission per decision: is this right?
-    decide([ compensate | Actions ], Window, {emit, Window#eep_win.agg}).
+    decide(Actions, Window, {emit, Window#eep_win.agg}).
 
 %% Process functionality: utils for running windows as a process.
 start(Window, AggMod, Interval) ->

--- a/src/eep_window.erl
+++ b/src/eep_window.erl
@@ -32,7 +32,6 @@
 
 -export([tumbling/4]).
 -export([sliding/4]).
--export([push/2]).
 -export([tick/1]).
 
 %% DEBUG
@@ -60,10 +59,6 @@ sliding(event, Size, Aggregate, Seed) ->
     W#eep_win{by=event}. %% TODO FIXME
 
 %% Window command interface.
-push(Event, #eep_win{by=time}=Win) ->
-    decide([{accumulate, Event}], Win);
-push(Event, #eep_win{by=event}=Win) ->
-    decide([{accumulate, Event}, tick], Win).
 
 %% A thin wrapper that allows to stop external parties ticking a by-event window.
 %% TODO THis might be unnecessary - maybe we don't need to make this restriction?

--- a/src/eep_window_monotonic.erl
+++ b/src/eep_window_monotonic.erl
@@ -61,7 +61,7 @@ new(Mod, Seed, eep_clock_count, CallbackFun, Interval) ->
 
 -spec push(#state{}, any()) -> {noop,#state{}} | {emit,#state{}}.
 push({CBFun, W0}, Event) ->
-    case eep_window:push(Event, W0) of
+    case eep_window:decide([{accumulate, Event}], W0) of
         {{emit, Em}, W1} ->
             CBFun(Em),
             {emit, {CBFun, W1}};

--- a/src/eep_window_monotonic.erl
+++ b/src/eep_window_monotonic.erl
@@ -64,7 +64,7 @@ push({CBFun, W0}, Event) ->
     case eep_window:decide([{accumulate, Event}], W0) of
         {{emit, Em}, W1} ->
             CBFun(Em),
-            {emit, {CBFun, W1}};
+            {emit, {CBFun, eep_window:reset(W1)}};
         {noop, W1} -> {noop, {CBFun, W1}}
     end.
 
@@ -73,5 +73,5 @@ tick({CBFun, W0}) ->
         {noop, W1} -> {noop, {CBFun, W1}};
         {{emit, Em}, W1} ->
             CBFun(Em),
-            {emit, {CBFun, W1}}
+            {emit, {CBFun, eep_window:reset(W1)}}
     end.

--- a/src/eep_window_periodic.erl
+++ b/src/eep_window_periodic.erl
@@ -70,7 +70,7 @@ new(AggMod, ClockMod, Seed, CallbackFun, Interval) ->
 
 -spec push(#eep_win{}, any()) -> {noop,#eep_win{}}.
 push({CBFun, Window}, Event) ->
-    {noop, Pushed} = eep_window:push(Event, Window),
+    {noop, Pushed} = eep_window:decide([{accumulate, Event}], Window),
     {noop, {CBFun, Pushed}}.
 
 tick({CBFun, Window}) ->

--- a/src/eep_window_periodic.erl
+++ b/src/eep_window_periodic.erl
@@ -78,5 +78,5 @@ tick({CBFun, Window}) ->
         {noop, Next} -> {noop, {CBFun, Next}};
         {{emit, Emission}, Next} ->
             CBFun(Emission),
-            {emit, {CBFun, Next}}
+            {emit, {CBFun, eep_window:reset(Next)}}
     end.

--- a/src/eep_window_sliding.erl
+++ b/src/eep_window_sliding.erl
@@ -67,6 +67,9 @@ push({CBFun, Win}, Event) ->
     case eep_window:decide([{accumulate, Event}, tick], Win) of
         {noop, Pushed} ->
             {noop, {CBFun, Pushed}};
+        {{emit, _}, #eep_win{count=C, size=S}=Pushed}
+          when C =< S ->
+            {noop, {CBFun, Pushed}};
         {{emit, Emission}, Pushed} ->
             CBFun(Emission),
             {emit, {CBFun, eep_window:compensate(Pushed)}}

--- a/src/eep_window_sliding.erl
+++ b/src/eep_window_sliding.erl
@@ -69,8 +69,7 @@ push({CBFun, Win}, Event) ->
             {noop, {CBFun, Pushed}};
         {{emit, Emission}, Pushed} ->
             CBFun(Emission),
-            {emit, {CBFun, Pushed}}
+            {emit, {CBFun, eep_window:compensate(Pushed)}}
     end.
 
-tick(_) ->
-    error({dont, tick, me, bro}).
+tick({_,_}=Win) -> {noop, Win}.

--- a/src/eep_window_sliding.erl
+++ b/src/eep_window_sliding.erl
@@ -32,6 +32,7 @@
 -export([new/3]).
 -export([new/4]).
 -export([push/2]).
+-export([tick/1]).
 
 -record(state, {
     size :: integer(),
@@ -63,10 +64,13 @@ new(Mod, Seed, CallbackFun, Size) ->
     {CallbackFun, eep_window:sliding(event, Size, Mod, Seed)}.
 
 push({CBFun, Win}, Event) ->
-    case eep_window:push(Event, Win) of
+    case eep_window:decide([{accumulate, Event}, tick], Win) of
         {noop, Pushed} ->
             {noop, {CBFun, Pushed}};
         {{emit, Emission}, Pushed} ->
             CBFun(Emission),
             {emit, {CBFun, Pushed}}
     end.
+
+tick(_) ->
+    error({dont, tick, me, bro}).

--- a/src/eep_window_sliding_time.erl
+++ b/src/eep_window_sliding_time.erl
@@ -38,7 +38,7 @@
     {CallbackFun, #eep_win{}}
       when CallbackFun :: fun((...) -> any()).
 new(Mod, ClockMod, CallbackFun, Size) ->
-    new(Mod, [], ClockMod, CallbackFun, Size).
+    new(Mod, ClockMod, [], CallbackFun, Size).
 
 -spec new(Mod::module(), ClockMod::module(), Seed::list(), CallbackFun, Size::integer()) ->
     {CallbackFun, #eep_win{}}
@@ -47,7 +47,7 @@ new(Mod, ClockMod, Seed, CallbackFun, Size) ->
     W0 = eep_window:sliding({clock, ClockMod, 1}, Size, Mod, Seed),
     C0 = W0#eep_win.clock,
     L0 = W0#eep_win.log,
-    L1 = eep_winlog:tick(ClockMod:at(C0), L0),
+    L1 = eep_winlog:tick(eep_clock:at(C0), L0),
     {CallbackFun, W0#eep_win{log=L1}}.
 
 push({CBFun, Win}, Event) ->
@@ -67,8 +67,8 @@ tick({CBFun, Win}) ->
     end.
 
 expire_and_emit(CBFun, #eep_win{}=Win0) ->
-    #eep_win{aggmod=AMod, agg=Agg, size=S, log=Log, clockmod=CM, clock=C}=Win0,
-    At = CM:at(C),
+    #eep_win{aggmod=AMod, agg=Agg, size=S, log=Log, clock=C}=Win0,
+    At = eep_clock:at(C),
     case eep_winlog:expire(At - S, Log) of
         {[], Current} -> %% Nothing expiring
             {noop, Win0#eep_win{log=Current}};

--- a/src/eep_window_sliding_time.erl
+++ b/src/eep_window_sliding_time.erl
@@ -53,7 +53,7 @@ new(Mod, Seed, ClockMod, CallbackFun, Size) ->
     {CallbackFun, eep_window:sliding({clock, ClockMod, Size}, 1, Mod, Seed)}.
 
 push({CBFun, Win}, Event) ->
-    case eep_window:push(Event, Win) of
+    case eep_window:decide([{accumulate, Event}], Win) of
         {noop, Pushed} ->
             {noop, {CBFun, Pushed}};
         {{emit, _}, _} ->

--- a/src/eep_window_sliding_time.erl
+++ b/src/eep_window_sliding_time.erl
@@ -34,22 +34,16 @@
 -export([push/2]).
 -export([tick/1]).
 
--record(state, {
-    size :: integer(),
-    mod :: module(),
-    seed = [] :: list(),
-    aggregate :: any(),
-    callback = undefined :: fun((...) -> any()),
-    count = 1 :: integer(),
-    prior = [] :: list()
-}).
-
--spec new(Mod::module(), ClockMod::module(), CallbackFun::fun((...) -> any()), Size::integer()) -> #state{}.
+-spec new(Mod::module(), ClockMod::module(), CallbackFun, Size::integer()) ->
+    {CallbackFun, #eep_win{}}
+      when CallbackFun :: fun((...) -> any()).
 new(Mod, ClockMod, CallbackFun, Size) ->
     new(Mod, [], ClockMod, CallbackFun, Size).
 
--spec new(Mod::module(), Seed::list(), ClockMod::module(), CallbackFun::fun((...) -> any()), Size::integer()) -> #state{}.
-new(Mod, Seed, ClockMod, CallbackFun, Size) ->
+-spec new(Mod::module(), ClockMod::module(), Seed::list(), CallbackFun, Size::integer()) ->
+    {CallbackFun, #eep_win{}}
+      when CallbackFun :: fun((...) -> any()).
+new(Mod, ClockMod, Seed, CallbackFun, Size) ->
     W0 = eep_window:sliding({clock, ClockMod, 1}, Size, Mod, Seed),
     C0 = W0#eep_win.clock,
     L0 = W0#eep_win.log,

--- a/src/eep_window_tumbling.erl
+++ b/src/eep_window_tumbling.erl
@@ -103,7 +103,7 @@ new(Mod, Seed, CallbackFun, Size) ->
 
 %-spec push(#state{}, any()) -> {noop,#state{}} | {emit,#state{}}.
 push({CBFun, Window}, Event) ->
-    case eep_window:push(Event, Window) of
+    case eep_window:decide([{accumulate, Event}, tick], Window) of
         {noop, Window1} ->
             {noop, {CBFun, Window1}};
         {{emit, Emission}, Window1} ->

--- a/src/eep_window_tumbling.erl
+++ b/src/eep_window_tumbling.erl
@@ -62,6 +62,7 @@
 -export([new/3]).
 -export([new/4]).
 -export([push/2]).
+-export([tick/1]).
 
 -record(state, {
     size :: integer(),
@@ -108,5 +109,7 @@ push({CBFun, Window}, Event) ->
             {noop, {CBFun, Window1}};
         {{emit, Emission}, Window1} ->
             CBFun(Emission),
-            {emit, {CBFun, Window1}}
+            {emit, {CBFun, eep_window:reset(Window1)}}
     end.
+
+tick({_, _}=Win) -> {noop, Win}.

--- a/src/eep_window_tumbling.erl
+++ b/src/eep_window_tumbling.erl
@@ -95,7 +95,7 @@ start(Mod, Size) ->
 %%
 -spec new(Mod::module(), CallbackFun::fun((...) -> any()), Size::integer()) ->#state{}.
 new(Mod, CallbackFun, Size) ->
-    {CallbackFun, eep_window:tumbling(event, Size, Mod, [])}.
+    new(Mod, [], CallbackFun, Size).
 
 -spec new(Mod::module(), Seed::list(), CallbackFun::fun((...) -> any()), Size::integer()) ->#state{}.
 new(Mod, Seed, CallbackFun, Size) ->

--- a/test/eep_erl_SUITE.erl
+++ b/test/eep_erl_SUITE.erl
@@ -77,19 +77,19 @@ groups() ->
             t_clock_wall
             , t_clock_count
             ]},
-        {win_tumbling, [], [
+        {win_tumbling, [sequence], [
             t_win_tumbling_inline,
             t_win_tumbling_process
             ]},
-        {win_sliding, [], [
+        {win_sliding, [sequence], [
             t_win_sliding_inline,
             t_win_sliding_process
             ]},
-        {win_periodic, [], [
+        {win_periodic, [sequence], [
             t_win_periodic_inline,
             t_win_periodic_process
             ]},
-        {win_monotonic, [], [
+        {win_monotonic, [sequence], [
             t_win_monotonic_inline,
             t_win_monotonic_process
             ]},

--- a/test/eep_erl_SUITE.erl
+++ b/test/eep_erl_SUITE.erl
@@ -128,19 +128,19 @@ t_clock_wall(_Config) ->
     true = C3#eep_clock.mark =< T1.
 
 t_clock_count(_Config) ->
-  count = eep_clock_count:name(),
-  C0 = eep_clock_count:new(2),
-  0  = eep_clock_count:at(C0),
-  {false, C1} = eep_clock_count:tick(C0),
-  0  = eep_clock_count:at(C1),
-  {true,C2} = eep_clock_count:tick(C1),
-  {true,C3}  = eep_clock_count:tock(C2),
-  {false,C4}  = eep_clock_count:tick(C3),
-
-  {true, C5} = eep_clock_count:tock(C4),
-  {true,C6} = eep_clock_count:tock(C5),
-  6 = eep_clock_count:at(C6),
-  6 = C6#eep_clock.mark.
+    M = eep_clock_count,
+    count = M:name(),
+    C0 = M:new(2),
+    0  = M:at(C0),
+    {noop, C1} = eep_clock:tick(M, C0),
+    1  = M:at(C1),
+    {tock, C2} = eep_clock:tick(M, C1),
+    {noop, C3} = eep_clock:tick(M, C2),
+    {tock, C4} = eep_clock:tick(M, C3),
+    {noop, C5} = eep_clock:tick(M, C4),
+    {tock, C6} = eep_clock:tick(M, C5),
+    6 = M:at(C6),
+    6 = C6#eep_clock.mark.
 
 t_win_tumbling_inline(_Config) ->
     W0  = eep_window_tumbling:new(eep_stats_count, fun(_Callback) -> boop end, 2),

--- a/test/eep_erl_SUITE.erl
+++ b/test/eep_erl_SUITE.erl
@@ -112,20 +112,18 @@ init_per_suite(Config) ->
     Config.
 
 t_clock_wall(_Config) ->
-    crock = eep_clock_wall:name(),
-    C0 = eep_clock_wall:new(1),
-    {eep_clock,_,At,_} = C0,
-    At = eep_clock_wall:at(C0),
+    M = eep_clock_wall,
+    crock = M:name(),
+    C0 = M:new(1),
     timer:sleep(1),
-    T0 = eep_clock_wall:ts(),
+    T0 = M:ts(),
     true = (T0 - C0#eep_clock.at) >= 1,
     timer:sleep(1),
-    {true, C1} = eep_clock_wall:tick(C0),
+    {tock, C1} = eep_clock:tick(M, C0),
     true = (C1#eep_clock.at - T0) >= 1,
     T1 = C1#eep_clock.at,
-    {true,C2} = eep_clock_wall:tick(C1),
-    {true,C3} = eep_clock_wall:tock(C2),
-    true = C3#eep_clock.mark =< T1.
+    {tock,C2} = eep_clock:tick(M, C1),
+    true = C2#eep_clock.mark =< T1.
 
 t_clock_count(_Config) ->
     M = eep_clock_count,

--- a/test/eep_erl_SUITE.erl
+++ b/test/eep_erl_SUITE.erl
@@ -342,7 +342,6 @@ t_win_periodic_process(_Config) ->
   receive
     { debug, Debug0 } ->
           {_, E0} = Debug0
-          %{state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},2,_} = Debug0
   end,
   Pid ! tick,
   Pid ! {debug, self()},
@@ -350,7 +349,6 @@ t_win_periodic_process(_Config) ->
   receive
     { debug, Debug1 } ->
           {_, E1} = Debug1
-          %{state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_} = Debug1
   end,
   Pid ! {push, foo},
   Pid ! {push, bar},
@@ -363,7 +361,6 @@ t_win_periodic_process(_Config) ->
   receive
     { debug, Debug2 } ->
           {_, E2} = Debug2
-          %{state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},6,_} = Debug2
   end,
   Pid ! tick,
   Pid ! {debug, self()},
@@ -371,7 +368,6 @@ t_win_periodic_process(_Config) ->
   receive
     { debug, Debug3 } ->
           {_, E3} = Debug3
-          %{state,0,eep_stats_count,eep_clock_wall,[],{eep_clock,_,_,0},0,_} = Debug3
   end,
   Pid ! stop.
 
@@ -379,9 +375,11 @@ t_win_monotonic_inline(_Config) ->
     W0 = eep_window_monotonic:new(eep_stats_count, eep_clock_count, fun(_) -> boop end, 0),
     {noop,W1} = eep_window_monotonic:push(W0,foo),
     {noop,W2} = eep_window_monotonic:push(W1,bar),
-    {state,undefined,eep_stats_count,[],eep_clock_count,{eep_clock,3,0,0},2,_} = W2,
+    {_, #eep_win{count=3}} = W2,
+    %{state,undefined,eep_stats_count,[],eep_clock_count,{eep_clock,3,0,0},2,_} = W2,
     {emit,W3} = eep_window_monotonic:tick(W2),
-    {state,undefined,eep_stats_count,[],eep_clock_count,{eep_clock,_,_,0},0,_} = W3,
+    {_, #eep_win{count=1}} = W3,
+    %{state,undefined,eep_stats_count,[],eep_clock_count,{eep_clock,_,_,0},0,_} = W3,
     {noop,W4} = eep_window_monotonic:push(W3,foo),
     {noop,W5} = eep_window_monotonic:push(W4,bar),
     {noop,W6} = eep_window_monotonic:push(W5,foo),
@@ -389,7 +387,8 @@ t_win_monotonic_inline(_Config) ->
     {noop,W8} = eep_window_monotonic:push(W7,foo),
     {noop,W9} = eep_window_monotonic:push(W8,bar),
     {emit,W10} = eep_window_monotonic:tick(W9),
-    {state,undefined,eep_stats_count,[],eep_clock_count,{eep_clock,_,_,0},0,_} = W10,
+    {_, #eep_win{count=1}} = W10,
+    %{state,undefined,eep_stats_count,[],eep_clock_count,{eep_clock,_,_,0},0,_} = W10,
     ok.
 
 t_win_monotonic_process(_config) ->
@@ -398,12 +397,14 @@ t_win_monotonic_process(_config) ->
     Pid ! {push, bar},
     Pid ! {debug, self()},
     receive
-    { debug, Debug0 } -> {state,undefined,eep_stats_count,[],eep_clock_count, {eep_clock,3,0,0},2,_}  = Debug0
+        { debug, Debug0 } ->
+            {_, #eep_win{count=3}} = Debug0
     end,
     Pid ! tick,
     Pid ! {debug, self()},
     receive
-    { debug, Debug1 } -> {state,undefined,eep_stats_count,[],eep_clock_count, {eep_clock,4,0,0},0,_}  = Debug1
+        { debug, Debug1 } ->
+            {_, #eep_win{count=1}} = Debug1
     end,
     Pid ! {push, foo},
     Pid ! {push, bar},
@@ -413,12 +414,14 @@ t_win_monotonic_process(_config) ->
     Pid ! {push, bar},
     Pid ! {debug, self()},
     receive
-    { debug, Debug2 } -> {state,undefined,eep_stats_count,[],eep_clock_count, {eep_clock,10,0,0},6,_}  = Debug2
+        { debug, Debug2 } ->
+            {_, #eep_win{count=7}} = Debug2
     end,
     Pid ! tick,
     Pid ! {debug, self()},
     receive
-    { debug, Debug3 } -> {state,undefined,eep_stats_count,[],eep_clock_count, {eep_clock,11,0,0},0,_}  = Debug3
+        { debug, Debug3 } ->
+            {_, #eep_win{count=1}} = Debug3
     end,
     Pid ! stop.
 

--- a/test/eep_erl_SUITE.erl
+++ b/test/eep_erl_SUITE.erl
@@ -129,15 +129,15 @@ t_clock_count(_Config) ->
     M = eep_clock_count,
     count = M:name(),
     C0 = M:new(2),
-    0  = M:at(C0),
+    0  = eep_clock:at(C0),
     {noop, C1} = eep_clock:tick(M, C0),
-    1  = M:at(C1),
+    1  = eep_clock:at(C1),
     {tock, C2} = eep_clock:tick(M, C1),
     {noop, C3} = eep_clock:tick(M, C2),
     {tock, C4} = eep_clock:tick(M, C3),
     {noop, C5} = eep_clock:tick(M, C4),
     {tock, C6} = eep_clock:tick(M, C5),
-    6 = M:at(C6),
+    6 = eep_clock:at(C6),
     6 = C6#eep_clock.mark.
 
 t_win_tumbling_inline(_Config) ->

--- a/test/prop_eep.erl
+++ b/test/prop_eep.erl
@@ -105,7 +105,7 @@ prop_monotonic_clock_count() ->
                Init = eep_clock_count:new(Interval),
                {Clock, Tocks} = lists:foldl(fun clock_handle/2,
                                             {Init, 0}, Events),
-               ExpectedTime = length(Events) - (length(Events) rem Interval),
+               ExpectedTime = length(Events),
                eep_clock_count:at(Clock) == ExpectedTime
                     andalso Tocks == length(Events) div Interval
            end).
@@ -237,7 +237,7 @@ prop_sliding_time_window() ->
             end).
 
 sliding_time_window(Length, Events) ->
-    W0 = eep_window:sliding({clock, eep_clock_count, Length}, Length, eep_stats_count, []),
+    W0 = eep_window:sliding({clock, eep_clock_count, Length}, 1, eep_stats_count, []),
     {_Wn, As} = lists:foldl(fun time_slider/2, {W0, []}, Events),
     lists:reverse(As).
 

--- a/test/prop_eep.erl
+++ b/test/prop_eep.erl
@@ -42,8 +42,8 @@
 -export([sliding_time_window/2]).
 -export([expected_time_slider/2]).
 -export([time_slider/2]).
--export([count_pushes/1]).
--export([stride/2]).
+-export([compress_time_buckets/1]).
+%-export([stride/2]).
 
 -define(epsilon, 1.0e-15).
 
@@ -221,12 +221,22 @@ prop_sliding_window() ->
                     andalso length(Noops) =< Size - 1
             end).
 
-push_folder(Ev, {#eep_win{by=event}=Win, As}) ->
-    {A, Win1} = eep_window:decide([{accumulate, Ev}, tick], Win),
-    {Win1, As++[A]};
-push_folder(Ev, {#eep_win{by=time}=Win, As}) ->
-    {A, Win1} = eep_window:decide([{accumulate, Ev}], Win),
-    {Win1, As++[A]}.
+push_folder(Ev, {#eep_win{by=By, compensating=Com}=Win, As}) ->
+    Tl = case By of event -> [tick]; time -> [] end,
+    L = [{accumulate, Ev} | Tl],
+    Post = case Com of true -> compensate; false -> reset end,
+    case eep_window:decide(L, Win) of
+        {{emit,_}=Em, Win1} ->
+            {eep_window:Post(Win1), As++[Em]};
+        {Other, Win1} ->
+            {Win1, As++[Other]}
+    end.
+%push_folder(Ev, {#eep_win{by=event}=Win, As}) ->
+%    {A, Win1} = eep_window:decide([{accumulate, Ev}, tick], Win),
+%    {Win1, As++[A]};
+%push_folder(Ev, {#eep_win{by=time}=Win, As}) ->
+%    {A, Win1} = eep_window:decide([{accumulate, Ev}], Win),
+%    {Win1, As++[A]}.
 
 prop_sliding_time_window() ->
     ?FORALL({Length, Events}, {pos_integer(), list(oneof([tick, push]))},
@@ -234,43 +244,41 @@ prop_sliding_time_window() ->
             begin
                 Actions = sliding_time_window(Length, Events),
                 Exp = expected_time_slider(Length, Events),
-                [ A || A <- Actions, A =/= noop ] == Exp
+                [ A || A <- lists:flatten(Actions), A =/= noop ] == Exp
             end).
 
+%% e.g.
+%% Length = 2
+%% [ push, push, tick, push, tick,                    tick,       push, tick, push, push, tick,        tick,                   tick ]
+%% [ noop, noop, noop, noop, [{emit, 3}, {emit, 2}], [{emit, 1}], noop, noop, noop, noop, [{emit, 3}], [{emit, 2}, {emit, 1}], noop ]
+
+expected_time_slider(Size, Events) ->
+    create_emissions(Size, compress_time_buckets(Events), []).
+
+compress_time_buckets(Raw) -> compress_time_buckets(Raw, 0, []).
+compress_time_buckets([], _, Compd) -> lists:reverse(Compd);
+compress_time_buckets([push | Raw], B, Bs) ->
+    compress_time_buckets(Raw, B+1, Bs);
+compress_time_buckets([tick | Raw], B, Bs) ->
+    compress_time_buckets(Raw, 0, [B | Bs]).
+
+create_emissions(S, Short, Emissions)
+  when length(Short) < S -> Emissions;
+create_emissions(_, [], Emissions) -> Emissions;
+create_emissions(Size, Buckets, Emissions) ->
+    [Bucket|Tail] = Buckets,
+    WinScope = lists:sublist(Buckets, Size),
+    WinTotal = lists:sum(WinScope),
+    create_emissions(Size, Tail, Emissions++[ {emit, N} || N <- lists:seq(WinTotal, WinTotal-Bucket+1, -1) ]).
+
 sliding_time_window(Length, Events) ->
-    W0 = eep_window:sliding({clock, eep_clock_count, Length}, 1, eep_stats_count, []),
+    W0 = eep_window_sliding_time:new(eep_stats_count, eep_clock_count, fun(_) -> ok end, Length),
     {_Wn, As} = lists:foldl(fun time_slider/2, {W0, []}, Events),
     lists:reverse(As).
 
 time_slider(push, {W, As}) ->
-    Actions =
-        case W#eep_win.by of
-            time -> [{accumulate, 1}];
-            event -> [{accumulate, 1}, tick]
-        end,
-    {A, W1} = eep_window:decide(Actions, W),
+    {A, W1} = eep_window_sliding_time:push(W, 1),
     {W1, [A | As]};
 time_slider(tick, {W, As}) ->
-    {A, W1} = eep_window:tick(W),
+    {A, W1} = eep_window_sliding_time:tick(W),
     {W1, [A | As]}.
-
-%% e.g.
-%% Length = 2, Interval = 2
-%% [ push, tick 1, push, push, tick 2, push, push, tick 3, tick 4  ]
-%% [ noop, noop,   noop, noop, emit 3, noop, noop, noop,   emit 2 ]
-expected_time_slider(WinSize, Events) ->
-    stride(WinSize, count_pushes(Events)).
-
-count_pushes(Events) ->
-    count_pushes(Events, 0, []).
-count_pushes([], _, Events) -> lists:reverse(Events);
-count_pushes([tick | Raw], N, Events) ->
-    count_pushes(Raw, 0, [ N | Events ]);
-count_pushes([push | Raw], N, Events) ->
-    count_pushes(Raw, N+1, Events).
-
-stride(Size, Events) when Size > length(Events) -> [];
-stride(Size, Events) ->
-    Window = lists:sublist(Events, Size),
-    Tail = lists:nthtail(Size, Events),
-    [{emit, lists:sum(Window)} | stride(Size, Tail)].

--- a/test/prop_eep.erl
+++ b/test/prop_eep.erl
@@ -111,14 +111,11 @@ prop_monotonic_clock_count() ->
            end).
 
 clock_handle(tick, {Clock, Tocks}) ->
-    case eep_clock_count:tick(Clock) of
-        {false, TickedClock} ->
+    case eep_clock:tick(eep_clock_count, Clock) of
+        {noop, TickedClock} ->
             {TickedClock, Tocks};
-        {true, TockingClock} ->
-            case eep_clock_count:tock(TockingClock) of
-                {true, Tocked} -> {Tocked, Tocks+1};
-                {false, Tocked} -> {Tocked, Tocks}
-            end
+        {tock, TockingClock} ->
+            {TockingClock, Tocks+1}
     end;
 clock_handle(Event, _Clock) ->
     error({unhandled_clock_event, Event}).

--- a/test/prop_eep.erl
+++ b/test/prop_eep.erl
@@ -87,10 +87,10 @@ prop_wall_clock() ->
                         timer:sleep(I),
                         case eep_clock:tick(eep_clock_wall, Cn) of
                             {noop, Cn1} ->
-                                Drift = eep_clock_wall:at(Cn1) - (eep_clock_wall:at(Cn) + I),
+                                Drift = eep_clock:at(Cn1) - (eep_clock:at(Cn) + I),
                                 {Cn1, [Cn|Cs], [Drift|Ds], Ts};
                             {tock, Cn2} ->
-                                Drift = eep_clock_wall:at(Cn2) - (eep_clock_wall:at(Cn) + I),
+                                Drift = eep_clock:at(Cn2) - (eep_clock:at(Cn) + I),
                                 {Cn2, [Cn|Cs], [Drift|Ds], Ts+1}
                         end end,
                 {_Cfinal, _Clocks, Drifts, Tocks} =
@@ -107,7 +107,7 @@ prop_monotonic_clock_count() ->
                {Clock, Tocks} = lists:foldl(fun clock_handle/2,
                                             {Init, 0}, Events),
                ExpectedTime = length(Events),
-               eep_clock_count:at(Clock) == ExpectedTime
+               eep_clock:at(Clock) == ExpectedTime
                     andalso Tocks == length(Events) div Interval
            end).
 
@@ -231,12 +231,6 @@ push_folder(Ev, {#eep_win{by=By, compensating=Com}=Win, As}) ->
         {Other, Win1} ->
             {Win1, As++[Other]}
     end.
-%push_folder(Ev, {#eep_win{by=event}=Win, As}) ->
-%    {A, Win1} = eep_window:decide([{accumulate, Ev}, tick], Win),
-%    {Win1, As++[A]};
-%push_folder(Ev, {#eep_win{by=time}=Win, As}) ->
-%    {A, Win1} = eep_window:decide([{accumulate, Ev}], Win),
-%    {Win1, As++[A]}.
 
 prop_sliding_time_window() ->
     ?FORALL({Length, Events}, {pos_integer(), list(oneof([tick, push]))},


### PR DESCRIPTION
Centralise a little more `eep_clock` functionality (`eep_clock:at/1`) and introduce an `origin` value to calculate total elapsed 'time'.
Make `eep_window` slightly less opinionated, moving certain decisions further out into the callback modules.
